### PR TITLE
Add rcgrep command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: trusty
 language: python
+cache: pip
 python:
     - 2.7
     - 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: trusty
 language: python
-cache: pip
 python:
     - 2.7
     - 3.5

--- a/bin/kevlar
+++ b/bin/kevlar
@@ -17,6 +17,7 @@ mains = {
     'dump': kevlar.dump.main,
     'find': kevlar.find.main,
     'collect': kevlar.collect.main,
+    'rcgrep': kevlar.rcgrep.main,
 }
 
 
@@ -31,6 +32,7 @@ def parser():
     kevlar.dump.subparser(subparsers)
     kevlar.find.subparser(subparsers)
     kevlar.collect.subparser(subparsers)
+    kevlar.rcgrep.subparser(subparsers)
 
     return parser
 

--- a/bin/kevlar
+++ b/bin/kevlar
@@ -22,13 +22,15 @@ mains = {
 
 
 def parser():
+    subcommandstr = '", "'.join(sorted(list(mains.keys())))
     parser = argparse.ArgumentParser()
     parser.add_argument('-v', '--version', action='version',
                         version='kevlar v{}'.format(kevlar.__version__))
     parser.add_argument('-l', '--logfile', metavar='FILE', default=sys.stderr,
                         type=argparse.FileType('w'))
     subparsers = parser.add_subparsers(dest='cmd', metavar='cmd',
-                                       help='dump | find | collect')
+                                       help='kevlar subcommand; choices '
+                                       'include "' + subcommandstr + '"')
     kevlar.dump.subparser(subparsers)
     kevlar.find.subparser(subparsers)
     kevlar.collect.subparser(subparsers)

--- a/kevlar/__init__.py
+++ b/kevlar/__init__.py
@@ -11,6 +11,7 @@ from . import fasta
 from . import dump
 from . import find
 from . import collect
+from . import rcgrep
 from .variantset import VariantSet
 from .timer import Timer
 import screed

--- a/kevlar/rcgrep.py
+++ b/kevlar/rcgrep.py
@@ -8,6 +8,7 @@
 # -----------------------------------------------------------------------------
 
 from __future__ import print_function
+from collections import deque
 import argparse
 import gzip
 import sys
@@ -15,8 +16,31 @@ import sys
 import kevlar
 
 
+def linesets(instream, before=0, after=0):
+    if before + after == 0:
+        for line in instream:
+            yield deque([line])
+    else:
+        lines = deque()
+        for line in instream:
+            lines.append(line)
+            if len(lines) == before + after + 1:
+                yield lines
+                lines.popleft()
+
+
+def positive_int(value):
+    ival = int(value)
+    if ival < 1:
+        message = '"{}" is not a positive integer'.format(value)
+        raise argparse.ArgumentTypeError(message)
+    return ival
+
+
 def subparser(subparsers):
     subparser = subparsers.add_parser('rcgrep')
+    subparser.add_argument('-A', '--after', type=positive_int, default=0)
+    subparser.add_argument('-B', '--before', type=positive_int, default=0)
     subparser.add_argument('-q', '--query', action='append', metavar='SEQ',
                            required=True)
     subparser.add_argument('file', nargs='+')
@@ -31,8 +55,10 @@ def main(args):
     for infile in args.file:
         openfunc = gzip.open if infile.endswith('.gz') else open
         instream = openfunc(infile, 'rt')
-        for line in instream:
+        for lineset in linesets(instream, args.before, args.after):
+            queryline = lineset[args.before]
             for seq in queryseqs:
-                if seq in line:
-                    print(line, end='')
+                if seq in queryline:
+                    for line in lineset:
+                        print(line, end='')
                     break

--- a/kevlar/rcgrep.py
+++ b/kevlar/rcgrep.py
@@ -17,6 +17,9 @@ import kevlar
 
 
 def linesets(instream, before=0, after=0):
+    """
+    Yield a line along with its before-and-after context.
+    """
     if before + after == 0:
         for line in instream:
             yield deque([line])

--- a/kevlar/rcgrep.py
+++ b/kevlar/rcgrep.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2017 The Regents of the University of California
+#
+# This file is part of kevlar (http://github.com/standage/kevlar) and is
+# licensed under the MIT license: see LICENSE.
+# -----------------------------------------------------------------------------
+
+from __future__ import print_function
+import argparse
+import gzip
+import sys
+
+import kevlar
+
+
+def subparser(subparsers):
+    subparser = subparsers.add_parser('rcgrep')
+    subparser.add_argument('-q', '--query', action='append', metavar='SEQ',
+                           required=True)
+    subparser.add_argument('file', nargs='+')
+
+
+def main(args):
+    queryseqs = set()
+    for qseq in args.query:
+        queryseqs.add(qseq)
+        queryseqs.add(kevlar.revcom(qseq))
+
+    for infile in args.file:
+        openfunc = gzip.open if infile.endswith('.gz') else open
+        instream = openfunc(infile, 'rt')
+        for line in instream:
+            for seq in queryseqs:
+                if seq in line:
+                    print(line, end='')
+                    break

--- a/kevlar/rcgrep.py
+++ b/kevlar/rcgrep.py
@@ -39,8 +39,10 @@ def positive_int(value):
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('rcgrep')
-    subparser.add_argument('-A', '--after', type=positive_int, default=0)
-    subparser.add_argument('-B', '--before', type=positive_int, default=0)
+    subparser.add_argument('-A', '--after', metavar='N', type=positive_int,
+                           default=0)
+    subparser.add_argument('-B', '--before', metavar='N', type=positive_int,
+                           default=0)
     subparser.add_argument('-q', '--query', action='append', metavar='SEQ',
                            required=True)
     subparser.add_argument('file', nargs='+')

--- a/tests/test_rcgrep.py
+++ b/tests/test_rcgrep.py
@@ -17,11 +17,12 @@ import kevlar
 def test_simple(capsys):
     args = type('', (), {})()
 
+    args.before = 0
+    args.after = 0
     args.query = ['ACCTTATTAAGTCACGCCC']
     args.file = ['tests/data/collect.beta.1.txt']
     kevlar.rcgrep.main(args)
 
     out, err = capsys.readouterr()
     for line in out.split('\t'):
-        print(line)
         assert args.query[0] in line or kevlar.revcom(args.query[0]) in line

--- a/tests/test_rcgrep.py
+++ b/tests/test_rcgrep.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2017 The Regents of the University of California
+#
+# This file is part of kevlar (http://github.com/standage/kevlar) and is
+# licensed under the MIT license: see LICENSE.
+# -----------------------------------------------------------------------------
+
+import pytest
+import sys
+
+import khmer
+import kevlar
+
+
+def test_simple(capsys):
+    args = type('', (), {})()
+
+    args.query = ['ACCTTATTAAGTCACGCCC']
+    args.file = ['tests/data/collect.beta.1.txt']
+    kevlar.rcgrep.main(args)
+
+    out, err = capsys.readouterr()
+    for line in out.split('\t'):
+        print(line)
+        assert args.query[0] in line or kevlar.revcom(args.query[0]) in line

--- a/tests/test_rcgrep.py
+++ b/tests/test_rcgrep.py
@@ -26,3 +26,52 @@ def test_simple(capsys):
     out, err = capsys.readouterr()
     for line in out.split('\t'):
         assert args.query[0] in line or kevlar.revcom(args.query[0]) in line
+
+
+def test_before(capsys):
+    args = type('', (), {})()
+
+    args.before = 1
+    args.after = 0
+    args.query = ['GTATACTACTGCGGCATGGGA']
+    args.file = ['tests/data/trio1/case2.fq']
+    kevlar.rcgrep.main(args)
+
+    out, err = capsys.readouterr()
+    outlines = out.split('\t')
+    for line1, line2 in zip(outlines[::2], outlines[1::2]):
+        assert 'chr1' in line1
+        assert args.query[0] in line2 or kevlar.revcom(args.query[0]) in line2
+
+
+def test_after(capsys):
+    args = type('', (), {})()
+
+    args.before = 0
+    args.after = 1
+    args.query = ['GTATACTACTGCGGCATGGGA']
+    args.file = ['tests/data/trio1/case2.fq']
+    kevlar.rcgrep.main(args)
+
+    out, err = capsys.readouterr()
+    outlines = out.split('\t')
+    for line1, line2 in zip(outlines[::2], outlines[1::2]):
+        assert args.query[0] in line1 or kevlar.revcom(args.query[0]) in line1
+        assert '+' == line2
+
+
+def test_before_and_after(capsys):
+    args = type('', (), {})()
+
+    args.before = 1
+    args.after = 1
+    args.query = ['GTATACTACTGCGGCATGGGA']
+    args.file = ['tests/data/trio1/case2.fq']
+    kevlar.rcgrep.main(args)
+
+    out, err = capsys.readouterr()
+    outlines = out.split('\t')
+    for l1, l2, l3 in zip(outlines[::2], outlines[1::2], outlines[2::2]):
+        assert 'chr1' in l1
+        assert args.query[0] in l2 or kevlar.revcom(args.query[0]) in l2
+        assert '+' == l3

--- a/tests/test_rcgrep.py
+++ b/tests/test_rcgrep.py
@@ -75,3 +75,19 @@ def test_before_and_after(capsys):
         assert 'chr1' in l1
         assert args.query[0] in l2 or kevlar.revcom(args.query[0]) in l2
         assert '+' == l3
+
+
+def test_compressed(capsys):
+    args = type('', (), {})()
+
+    args.before = 1
+    args.after = 0
+    args.query = ['CATTACACTGCAGTTAAAACAAATTCTGTGCTTTTCACGGGAGCAGCCCAAA']
+    args.file = ['tests/data/trio2/case1.fq.gz']
+    kevlar.rcgrep.main(args)
+
+    out, err = capsys.readouterr()
+    outlines = out.split('\t')
+    for line1, line2 in zip(outlines[::2], outlines[1::2]):
+        assert line1.startswith('@') and 'seq0' in line1
+        assert args.query[0] in line2 or kevlar.revcom(args.query[0]) in line2


### PR DESCRIPTION
I've been using grep and zgrep for searching files for sequences and their reverse complements. Added a simple command to make this easier. Addresses a few pain points I've had:

- searches for sequences and their revcomps simultaneously
- handles plain text and gzip-compressed files seamlessly
- supports the `-A` and `-B` options from grep
- supports multiple files AND multiple queries