### PR TITLE
[WIP] Introduce k-mer mask to "kevlar collect"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 dist: trusty
 language: python
+cache:
+    directories:
+        - $HOME/virtualenv/python2.7
+        - $HOME/virtualenv/python3.5
 python:
     - 2.7
     - 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - 3.5
 install:
     - pip install --upgrade pip setuptools pytest pep8 cython
-    - pip install git+https://github.com/pysam-developers/pysam.git
+    - pip install pysam
     - pip install git+https://github.com/dib-lab/khmer.git@feature/consume_bitsplit
     - pip install .
 script:

--- a/kevlar/collect.py
+++ b/kevlar/collect.py
@@ -56,8 +56,8 @@ def subparser(subparsers):
 def load_mask(maskfile, ksize, memory, logfile=sys.stderr):
     print('[kevlar::collect] Loading k-mer mask from ' + maskfile,
           file=logfile)
-    buckets = memory * khmer._buckets_per_byte / 4
-    mask = khmer.Nodetable(args.ksize, buckets, 4)
+    buckets = memory * khmer._buckets_per_byte['nodegraph'] / 4
+    mask = khmer.Nodetable(ksize, int(buckets), 4)
     nr, nk = mask.consume_seqfile(maskfile)
     message = '    {:d} reads and {:d} k-mers consumed'.format(nr, nk)
     print(message, file=logfile)
@@ -163,7 +163,7 @@ def main(args):
     variants = kevlar.VariantSet()
     mask = None
     if args.mask:
-        mask = load_mask(args.mask, args.mask_memory, args.ksize)
+        mask = load_mask(args.mask, args.ksize, args.mask_memory)
 
     load_all_inputs(args.find_output, countgraph, variants, mask,
                     args.minabund, args.max_fpr, args.logfile)

--- a/kevlar/collect.py
+++ b/kevlar/collect.py
@@ -30,9 +30,10 @@ def subparser(subparsers):
                            'k-mer novel; used to filter out k-mers with '
                            'inflated abundances; should equal the value of '
                            '--case_min used in "kevlar find"; default is 5')
-    subparser.add_argument('--max-fpr', type=float, default=0.1, metavar='FPR',
-                           help='terminate if the expected false positive rate'
-                           ' is higher than the specified FPR; default is 0.1')
+    subparser.add_argument('--max-fpr', type=float, metavar='FPR',
+                           default=0.001, help='terminate if the expected '
+                           'false positive rate is higher than the specified '
+                           'FPR; default is 0.001')
     subparser.add_argument('--mask', metavar='FILE', type=str, default=None,
                            help='ignore any k-mers present in the provided '
                            'sequence file')

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -48,7 +48,8 @@ def test_load_all_inputs():
     filepattern = 'tests/data/trio1/novel_1_1,2_batch{:d}.txt'
     infilenames = [filepattern.format(batch) for batch in batches]
 
-    kevlar.collect.load_all_inputs(infilenames, cg, vs, minabund, maxfpr, log)
+    kevlar.collect.load_all_inputs(infilenames, cg, vs, None, minabund, maxfpr,
+                                   log)
     assert vs.nkmers == 6
     assert vs.nkmerinst == 49
     assert vs.nreads == 10
@@ -62,7 +63,8 @@ def test_load_all_inputs_alpha():
     log = StringIO()
     infilenames = ['tests/data/collect.alpha.txt']
 
-    kevlar.collect.load_all_inputs(infilenames, cg, vs, minabund, maxfpr, log)
+    kevlar.collect.load_all_inputs(infilenames, cg, vs, None, minabund, maxfpr,
+                                   log)
     assert 'CAGGCCAGGGATCGCCGTG' not in vs.kmers and \
            kevlar.revcom('CAGGCCAGGGATCGCCGTG') not in vs.kmers
 
@@ -80,7 +82,8 @@ def test_load_all_inputs_beta():
     log = StringIO()
     infilenames = glob.glob('tests/data/collect.beta.?.txt')
 
-    kevlar.collect.load_all_inputs(infilenames, cg, vs, minabund, maxfpr, log)
+    kevlar.collect.load_all_inputs(infilenames, cg, vs, None, minabund, maxfpr,
+                                   log)
     assert vs.nreads == 8
 
     readseq = 'TTAACTCTAGATTAGGGGCGTGACTTAATAAGGTGTGGGCCTAAGCGTCT'

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -18,11 +18,11 @@ import khmer
 import kevlar
 
 
-def test_load_mask():
-    mask = kevlar.collect.load_mask('tests/data/bogus-genome/refr.fa', 25, 1e7)
-    assert mask.get('GGCCCCGAACTAGGGGGCCTACGTT') > 0
-    assert mask.get('GCTGGCTAAATTTTCATACTAACTA') > 0
-    assert mask.get('G' * 25) == 0
+def test_load_refr():
+    refr = kevlar.collect.load_refr('tests/data/bogus-genome/refr.fa', 25, 1e7)
+    assert refr.get('GGCCCCGAACTAGGGGGCCTACGTT') > 0
+    assert refr.get('GCTGGCTAAATTTTCATACTAACTA') > 0
+    assert refr.get('G' * 25) == 0
 
 
 def test_recalc_abund_beta():
@@ -68,12 +68,12 @@ def test_load_novel_kmers_beta():
     assert vs.nreads == 0
 
 
-def test_load_novel_kmers_withmask():
+def test_load_novel_kmers_withrefr():
     kmer = 'AGGGGCGTGACTTAATAAG'
     filelist = glob.glob('tests/data/collect.beta.?.txt')
     countgraph = kevlar.collect.recalc_abund(filelist, 19, 1e3)
-    mask = khmer.Nodetable(19, 1e3, 2)
-    mask.add(kmer)
-    vs = kevlar.collect.load_novel_kmers(filelist, countgraph, mask)
+    refr = khmer.Nodetable(19, 1e3, 2)
+    refr.add(kmer)
+    vs = kevlar.collect.load_novel_kmers(filelist, countgraph, refr)
     assert vs.nkmers == 3
     assert kmer not in vs.kmers and kevlar.revcom(kmer) not in vs.kmers

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -18,74 +18,62 @@ import khmer
 import kevlar
 
 
-# @pytest.mark.parametrize('filename,creads,ckmers,ukmers,kmerinst', [
-#     ('tests/data/trio1/novel_1_1,2.txt', 18, 684, 13, 171),
-#     ('tests/data/trio1/novel_2_1,2.txt', 53, 2014, 39, 540),
-#     ('tests/data/trio1/novel_3_1,2.txt', 178, 6764, 424, 5782),
-#     ('tests/data/trio1/novel_4_1,2.txt', 16, 608, 11, 99),
-#     ('tests/data/trio1/novel_5_3,4.txt', 16, 553, 9, 109),
-#     ('tests/data/trio1/novel_6_5,6.txt', 9, 336, 2, 9),
-# ])
-# def test_load_input(filename, creads, ckmers, ukmers, kmerinst):
-#     ng = khmer.Nodegraph(13, 3e5 / 4, 4)
-#     vs = kevlar.VariantSet()
-#     with open(filename, 'r') as infile:
-#         nreads, nkmers = kevlar.collect.load_input(infile, ng, vs)
-#     assert nreads == creads
-#     assert nkmers == ckmers
-#     assert vs.nkmers == ukmers
-#     assert vs.nkmerinst == kmerinst
+def test_load_mask():
+    mask = kevlar.collect.load_mask('tests/data/bogus-genome/refr.fa', 25, 1e7)
+    assert mask.get('GGCCCCGAACTAGGGGGCCTACGTT') > 0
+    assert mask.get('GCTGGCTAAATTTTCATACTAACTA') > 0
+    assert mask.get('G' * 25) == 0
 
 
-def test_load_all_inputs():
-    cg = khmer.Countgraph(13, 2e6 / 4, 4)
-    vs = kevlar.VariantSet()
-    minabund = 8
-    maxfpr = 0.2
-    log = StringIO()
+def test_recalc_abund_beta():
+    filelist = glob.glob('tests/data/collect.beta.?.txt')
+    countgraph = kevlar.collect.recalc_abund(filelist, 19, 1e3)
 
-    batches = [3, 4, 5, 7, 8]
-    filepattern = 'tests/data/trio1/novel_1_1,2_batch{:d}.txt'
-    infilenames = [filepattern.format(batch) for batch in batches]
-
-    kevlar.collect.load_all_inputs(infilenames, cg, vs, None, minabund, maxfpr,
-                                   log)
-    assert vs.nkmers == 6
-    assert vs.nkmerinst == 49
-    assert vs.nreads == 10
-
-
-def test_load_all_inputs_alpha():
-    cg = khmer.Countgraph(19, 4e4 / 4, 4)
-    vs = kevlar.VariantSet()
-    minabund = 8
-    maxfpr = 0.2
-    log = StringIO()
-    infilenames = ['tests/data/collect.alpha.txt']
-
-    kevlar.collect.load_all_inputs(infilenames, cg, vs, None, minabund, maxfpr,
-                                   log)
-    assert 'CAGGCCAGGGATCGCCGTG' not in vs.kmers and \
-           kevlar.revcom('CAGGCCAGGGATCGCCGTG') not in vs.kmers
-
-    kmers = ['TAGGGGCGTGACTTAATAA', 'AGGGGCGTGACTTAATAAG',
-             'GGGGCGTGACTTAATAAGG', 'GGGCGTGACTTAATAAGGT']
+    kmers = [
+        'AGGGGCGTGACTTAATAAG', 'GGGCGTGACTTAATAAGGT',
+        'TAGGGGCGTGACTTAATAA', 'GGGGCGTGACTTAATAAGG',
+    ]
     for kmer in kmers:
+        assert countgraph.get(kmer) == 8
+
+
+def test_load_novel_kmers_alpha():
+    filelist = ['tests/data/collect.alpha.txt']
+    countgraph = kevlar.collect.recalc_abund(filelist, 19, 1e3)
+    vs = kevlar.collect.load_novel_kmers(filelist, countgraph)
+    assert vs.nkmers == 4
+    assert vs.nreads == 8
+
+    badkmers = ['CAGGCCAGGGATCGCCGTG']
+    goodkmers = [
+        'AGGGGCGTGACTTAATAAG', 'GGGCGTGACTTAATAAGGT',
+        'TAGGGGCGTGACTTAATAA', 'GGGGCGTGACTTAATAAGG',
+    ]
+    for kmer in badkmers:
+        assert kmer not in vs.kmers and kevlar.revcom(kmer) not in vs.kmers
+    for kmer in goodkmers:
         assert kmer in vs.kmers or kevlar.revcom(kmer) in vs.kmers
 
 
-def test_load_all_inputs_beta():
-    cg = khmer.Countgraph(19, 4e4 / 4, 4)
-    vs = kevlar.VariantSet()
-    minabund = 8
-    maxfpr = 0.2
-    log = StringIO()
-    infilenames = glob.glob('tests/data/collect.beta.?.txt')
-
-    kevlar.collect.load_all_inputs(infilenames, cg, vs, None, minabund, maxfpr,
-                                   log)
+def test_load_novel_kmers_beta():
+    filelist = glob.glob('tests/data/collect.beta.?.txt')
+    countgraph = kevlar.collect.recalc_abund(filelist, 19, 1e3)
+    vs = kevlar.collect.load_novel_kmers(filelist, countgraph)
+    assert vs.nkmers == 4
     assert vs.nreads == 8
 
-    readseq = 'TTAACTCTAGATTAGGGGCGTGACTTAATAAGGTGTGGGCCTAAGCGTCT'
-    for kmer in cg.get_kmers(readseq):
-        assert cg.get(kmer) == 8
+    countgraph = kevlar.collect.recalc_abund(filelist, 19, 1e3)
+    vs = kevlar.collect.load_novel_kmers(filelist, countgraph, minabund=9)
+    assert vs.nkmers == 0
+    assert vs.nreads == 0
+
+
+def test_load_novel_kmers_withmask():
+    kmer = 'AGGGGCGTGACTTAATAAG'
+    filelist = glob.glob('tests/data/collect.beta.?.txt')
+    countgraph = kevlar.collect.recalc_abund(filelist, 19, 1e3)
+    mask = khmer.Nodetable(19, 1e3, 2)
+    mask.add(kmer)
+    vs = kevlar.collect.load_novel_kmers(filelist, countgraph, mask)
+    assert vs.nkmers == 3
+    assert kmer not in vs.kmers and kevlar.revcom(kmer) not in vs.kmers

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -53,6 +53,8 @@ def test_trio2():
     args.debug = False
     args.minabund = 8
     args.collapse = True
+    args.mask = None
+    args.mask_memory = None
     args.find_output = findoutfiles
     args.logfile = StringIO()
     kevlar.collect.main(args)


### PR DESCRIPTION
Work in progress for addressing #46. Introduces an additional filter to check potentially "novel" k-mers. If the k-mer is in the reference genome (as determined by a nodetable query) we ignore it. We've been seeing many cases in which a reportedly "novel" k-mer is actually just discarded in both of the parents because all reads containing it are perfect matches, whereas the proband has a sufficient number of erroneous reads to satisfy the case coverage criterion.