### PR TITLE
Replace all instances of StringIO in tests with capsys

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,5 +3,4 @@ show_missing = True
 
 [run]
 branch = True
-omit =
-    kevlar/_version.py
+omit = kevlar/_version.py, kevlar/tests/*.py

--- a/kevlar/dump.py
+++ b/kevlar/dump.py
@@ -12,6 +12,7 @@ import argparse
 
 import pysam
 import khmer
+from khmer import khmer_args
 
 import kevlar
 
@@ -31,8 +32,9 @@ def subparser(subparsers):
                            'declared, reads passing either filter will be '
                            'kept')
     subparser.add_argument('--maskmemory', metavar='SIZE', default=2e9,
-                           type=float, help='memory to be occupied by genome '
-                           'mask; default is 2e9 (2G)')
+                           type=khmer_args.memory_setting,
+                           help='memory to be occupied by genome mask; default'
+                           ' is 2G')
     subparser.add_argument('--mask-k', metavar='K', default=31, type=int,
                            help='k size for genome mask')
     subparser.add_argument('--out', metavar='FILE',

--- a/kevlar/tests/test_collect.py
+++ b/kevlar/tests/test_collect.py
@@ -10,10 +10,6 @@
 import glob
 import pytest
 import sys
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 import khmer
 import kevlar
 

--- a/kevlar/tests/test_filter.py
+++ b/kevlar/tests/test_filter.py
@@ -10,10 +10,6 @@
 import glob
 import pytest
 import sys
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 import khmer
 import kevlar
 

--- a/kevlar/tests/test_variant_set.py
+++ b/kevlar/tests/test_variant_set.py
@@ -8,10 +8,6 @@
 # -----------------------------------------------------------------------------
 
 import pytest
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 import kevlar
 from kevlar import VariantSet
 
@@ -41,10 +37,11 @@ def test_vset_contigs(basicvset):
     assert list(basicvset.contigs.keys()) == ['AATTTTTAA']
 
 
-def test_vset_write(basicvset):
-    out = StringIO()
-    basicvset.write(out)
+def test_vset_write(basicvset, capsys):
+    from sys import stdout
+    basicvset.write(stdout)
+    out, err = capsys.readouterr()
     outtest = ('Contig,ContigRevCom\tNumReads\tNumKmers\tReads\tKmers\n'
                'AATTTTTAA,TTAAAAATT\t4\t2\tread1,read2,read3,read4'
                '\tAAAAA,TAAAA\n')
-    assert out.getvalue() == outtest
+    assert out == outtest


### PR DESCRIPTION
Closes #43. 

P.S. Drop in test coverage is from excluding the test scripts themselves.