### PR TITLE
Report version

### DIFF
--- a/kevlar/__main__.py
+++ b/kevlar/__main__.py
@@ -29,4 +29,6 @@ def main(args=None):
 
     assert args.cmd in kevlar.cli.mains
     mainmethod = kevlar.cli.mains[args.cmd]
+    versionmessage = '[kevlar] running version {}'.format(kevlar.__version__)
+    print(versionmessage, file=args.logfile)
     mainmethod(args)

--- a/kevlar/__main__.py
+++ b/kevlar/__main__.py
@@ -21,10 +21,10 @@ def main(args=None):
     If no arguments are passed to the function, parse them from the command
     line.
     """
-    if args is None:
+    if args is None:  # pragma: no cover
         args = kevlar.cli.parser().parse_args()
 
-    if args.cmd is None:
+    if args.cmd is None:  # pragma: no cover
         kevlar.cli.parser().parse_args(['-h'])
 
     assert args.cmd in kevlar.cli.mains

--- a/kevlar/tests/test_cli.py
+++ b/kevlar/tests/test_cli.py
@@ -15,7 +15,8 @@ def test_help(capsys):
     with pytest.raises(SystemExit):
         kevlar.cli.parser().parse_args(['-h'])
     out, err = capsys.readouterr()
-    assert 'show this help message and exit' in out
+    msg = 'show this help message and exit'
+    assert msg in out or msg in err
 
 
 def test_version(capsys):

--- a/kevlar/tests/test_cli.py
+++ b/kevlar/tests/test_cli.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2017 The Regents of the University of California
+#
+# This file is part of kevlar (http://github.com/standage/kevlar) and is
+# licensed under the MIT license: see LICENSE.
+# -----------------------------------------------------------------------------
+
+import pytest
+import kevlar
+
+
+def test_help(capsys):
+    with pytest.raises(SystemExit):
+        kevlar.cli.parser().parse_args(['-h'])
+    out, err = capsys.readouterr()
+    assert 'show this help message and exit' in out
+
+
+def test_version(capsys):
+    with pytest.raises(SystemExit):
+        kevlar.cli.parser().parse_args(['-v'])
+    out, err = capsys.readouterr()
+    assert kevlar.__version__ in out
+
+
+@pytest.mark.parametrize('subcommand', [s for s in kevlar.cli.mains])
+def test_help_sub(subcommand, capsys):
+    with pytest.raises(SystemExit):
+        kevlar.cli.parser().parse_args([subcommand, '-h'])
+    out, err = capsys.readouterr()
+    assert subcommand in out
+    assert 'show this help message and exit' in out

--- a/kevlar/tests/test_cli.py
+++ b/kevlar/tests/test_cli.py
@@ -15,15 +15,14 @@ def test_help(capsys):
     with pytest.raises(SystemExit):
         kevlar.cli.parser().parse_args(['-h'])
     out, err = capsys.readouterr()
-    msg = 'show this help message and exit'
-    assert msg in out or msg in err
+    assert 'show this help message and exit' in out
 
 
 def test_version(capsys):
     with pytest.raises(SystemExit):
         kevlar.cli.parser().parse_args(['-v'])
     out, err = capsys.readouterr()
-    assert kevlar.__version__ in out
+    assert kevlar.__version__ in out or kevlar.__version__ in err
 
 
 @pytest.mark.parametrize('subcommand', [s for s in kevlar.cli.mains])


### PR DESCRIPTION
Reports the kevlar version whenever any command runs past option parsing (i.e. if it doesn't terminate immediately to with `-h|--help` or `-v|--version`). Also adds some tests to enforce expected CLI behaviors for subcommands.