### PR TITLE
Refactoring overlap code into its own module

### DIFF
--- a/kevlar/__init__.py
+++ b/kevlar/__init__.py
@@ -14,6 +14,7 @@ except:  # pragma: no cover
 from collections import namedtuple
 import sys
 from kevlar import seqio
+from kevlar import overlap
 from kevlar.seqio import parse_augmented_fastq, print_augmented_fastq
 from kevlar import dump
 from kevlar import novel

--- a/kevlar/assemble.py
+++ b/kevlar/assemble.py
@@ -36,16 +36,6 @@ def subparser(subparsers):
                            'Fastq format')
 
 
-def print_read_pair(read1, pos1, read2, pos2, ksize, offset, overlap,
-                    sameorient, outstream):
-    seq2 = read2.sequence if sameorient else kevlar.revcom(read2.sequence)
-    print('\nDEBUG shared interesting kmer: ', read1.name,
-          ' --(overlap={:d})'.format(overlap),
-          '(offset={:d})({})--> '.format(offset, sameorient), read2.name, '\n',
-          read1.sequence, '\n', ' ' * pos1, '|' * ksize, '\n', ' ' * offset,
-          seq2, '\n', sep='', file=outstream)
-
-
 def merge_pair(pair):
     """
     Assemble a pair of overlapping reads.

--- a/kevlar/assemble.py
+++ b/kevlar/assemble.py
@@ -99,7 +99,7 @@ def load_reads(instream, logstream=None):
     reads = dict()
     kmers = defaultdict(set)
     for n, record in enumerate(kevlar.parse_augmented_fastq(instream), 1):
-        if logstream and n % 10000 == 0:
+        if logstream and n % 10000 == 0:  # pragma: no cover
             print('[kevlar::assemble]    loaded {:d} reads'.format(n),
                   file=logstream)
         reads[record.name] = record
@@ -109,103 +109,123 @@ def load_reads(instream, logstream=None):
     return reads, kmers
 
 
-def graph_init(reads, kmers, maxabund=500, logstream=None):
+def graph_init_abund_check_pass(numreads, minkmer, minabund=5, maxabund=500,
+                                logstream=None):
+    """Check whether the k-mer falls within the expected range of abundance."""
+    if maxabund and numreads > maxabund:
+        msg = '            skipping k-mer with abundance {:d}'.format(numreads)
+        print(msg, file=logstream)
+        return False
+    if minabund and numreads < minabund:
+        message = '[kevlar::assemble] WARNING: k-mer {}'.format(minkmer)
+        message += ' (rev. comp. {})'.format(kevlar.revcom(minkmer))
+        message += ' only has abundance {:d}'.format(len(readnames))
+        out = logstream if logstream is not None else sys.stderr
+        print(message, file=out)
+        return False
+    return True
+
+
+def graph_add_edge(graph, pair, minkmer):
+    """
+    Add edge between two nodes in the "shared interesting k-mer" read graph.
+
+    If the edge already exists, make sure that the existing edge matches the
+    edge that would have been added.
+    """
+    tailname, headname = pair.tail.name, pair.head.name
+    if tailname in graph and headname in graph[tailname]:
+        assert graph[tailname][headname]['offset'] == pair.offset
+        if graph[tailname][headname]['tail'] == tailname:
+            assert graph[tailname][headname]['overlap'] == pair.overlap
+        graph[tailname][headname]['ikmers'].add(minkmer)
+    else:
+        graph.add_edge(tailname, headname, offset=pair.offset,
+                       overlap=pair.overlap, ikmers=set([minkmer]),
+                       orient=pair.sameorient, tail=tailname)
+
+
+def graph_init(reads, kmers, minabund=5, maxabund=500, logstream=None):
+    """
+    Initialize the "shared interesting k-mer" read graph.
+
+    Iterate through each interesting k-mer, consider every pair of reads
+    containing that k-mer, and determine whether there should be a edge between
+    the pair of reads in the graph.
+    """
     graph = networkx.Graph()
     nkmers = len(kmers)
     for n, minkmer in enumerate(kmers, 1):
-        if n % 100 == 0:
+        if n % 100 == 0:  # pragma: no cover
             msg = 'processed {:d}/{:d} shared novel k-mers'.format(n, nkmers)
             print('[kevlar::assemble]    ', msg, sep='', file=logstream)
+
         readnames = kmers[minkmer]
-        if maxabund and len(readnames) > maxabund:
-            msg = '            skipping k-mer with abundance {:d}'.format(
-                len(readnames)
-            )
-            print(msg, file=logstream)
+        if not graph_init_abund_check_pass(len(readnames), minkmer, minabund,
+                                           maxabund, logstream):
             continue
-        if len(readnames) < 2:
-            message = '[kevlar::assemble] WARNING: k-mer {}'.format(minkmer)
-            message += ' (rev. comp. {})'.format(kevlar.revcom(minkmer))
-            message += ' only has abundance {:d}'.format(len(readnames))
-            out = logstream if logstream is not None else sys.stderr
-            print(message, file=out)
-            continue
+
         readset = [reads[rn] for rn in readnames]
         for read1, read2 in itertools.combinations(readset, 2):
             pair = kevlar.overlap.calc_offset(read1, read2, minkmer, logstream)
             if pair is kevlar.overlap.INCOMPATIBLE_PAIR:
                 # Shared k-mer but bad overlap
                 continue
-            tailname, headname = pair.tail.name, pair.head.name
-            if tailname in graph and headname in graph[tailname]:
-                assert graph[tailname][headname]['offset'] == pair.offset
-                if graph[tailname][headname]['tail'] == tailname:
-                    assert graph[tailname][headname]['overlap'] == pair.overlap
-            else:
-                graph.add_edge(tailname, headname, offset=pair.offset,
-                               overlap=pair.overlap, ikmer=minkmer,
-                               orient=pair.sameorient, tail=tailname)
+            graph_add_edge(graph, pair, minkmer)
     return graph
 
 
-def assemble_with_greed(reads, kmers, graph):
-    pass
+def fetch_largest_overlapping_pair(graph, reads):
+    """
+    Grab the edge with the largest overlap in the graph.
+
+    Sort the edges using 3 criteria. The first is the primary criterion, the
+    other two ensure deterministic behavior.
+        - overlap (largest first)
+        - lexicographically smaller read name
+        - lexicographically larger read name
+    """
+    edges = sorted(
+        graph.edges(),
+        reverse=True,
+        key=lambda e: (
+            graph[e[0]][e[1]]['overlap'],
+            max(e),
+            min(e),
+        )
+    )
+    read1, read2 = edges[0]  # biggest overlap (greedy algorithm)
+    if read2 == graph[read1][read2]['tail']:
+        read1, read2 = read2, read1
+    return kevlar.overlap.OverlappingReadPair(
+        tail=reads[read1],
+        head=reads[read2],
+        offset=graph[read1][read2]['offset'],
+        overlap=graph[read1][read2]['overlap'],
+        sameorient=graph[read1][read2]['orient'],
+    )
 
 
-def main(args):
-    debugout = None
-    if args.debug:
-        debugout = args.logfile
-
-    reads, kmers = load_reads(kevlar.open(args.augfastq, 'r'), debugout)
-    inputreads = list(reads.keys())
-    graph = graph_init(reads, kmers, args.max_abund, debugout)
-    if args.gml:
-        networkx.write_gml(graph, args.gml)
-        message = '[kevlar::assemble] graph written to {}'.format(args.gml)
-        print(message, file=args.logfile)
-
-    ccs = list(networkx.connected_components(graph))
-    assert len(ccs) == 1
-
+def assemble_with_greed(reads, kmers, graph, debugout=None):
+    """Find shortest common superstring using a greedy assembly algorithm."""
     count = 0
     while len(graph.edges()) > 0:
         count += 1
-        # Sort the edges using 3 criteria. The first is the primary criterion,
-        # the other two ensure deterministic behavior.
-        #     - overlap (largest first)
-        #     - lexicographically smaller read name
-        #     - lexicographically larger read name
-        edges = sorted(
-            graph.edges(),
-            reverse=True,
-            key=lambda e: (
-                graph[e[0]][e[1]]['overlap'],
-                max(e),
-                min(e),
-            )
-        )
-        read1, read2 = edges[0]  # biggest overlap (greedy algorithm)
-        if read2 == graph[read1][read2]['tail']:
-            read1, read2 = read2, read1
-        pair = kevlar.overlap.OverlappingReadPair(
-            tail=reads[read1],
-            head=reads[read2],
-            offset=graph[read1][read2]['offset'],
-            overlap=graph[read1][read2]['overlap'],
-            sameorient=graph[read1][read2]['orient'],
-        )
+
+        pair = fetch_largest_overlapping_pair(graph, reads)
         newname = 'contig{:d}'.format(count)
         newrecord = merge_and_reannotate(pair, newname)
         if debugout:
-            print('### DEBUG', read1, read2, pair.offset, pair.overlap,
-                  pair.sameorient, file=debugout)
+            print('### DEBUG', pair.tail.name, pair.head.name, pair.offset,
+                  pair.overlap, pair.sameorient, file=debugout)
             kevlar.print_augmented_fastq(newrecord, debugout)
         for kmer in newrecord.ikmers:
             kmerseq = kevlar.revcommin(kmer.sequence)
             for readname in kmers[kmerseq]:
                 already_merged = readname not in graph
-                current_contig = readname in [read1, read2, newname]
+                current_contig = readname in [
+                    pair.tail.name, pair.head.name, newname
+                ]
                 if already_merged or current_contig:
                     continue
                 otherrecord = reads[readname]
@@ -226,8 +246,27 @@ def main(args):
             kmers[kmerseq].add(newrecord.name)
         reads[newrecord.name] = newrecord
         graph.add_node(newrecord.name)
-        graph.remove_node(read1)
-        graph.remove_node(read2)
+        graph.remove_node(pair.tail.name)
+        graph.remove_node(pair.head.name)
+
+
+def main(args):
+    debugout = None
+    if args.debug:
+        debugout = args.logfile
+
+    reads, kmers = load_reads(kevlar.open(args.augfastq, 'r'), debugout)
+    inputreads = list(reads)
+    graph = graph_init(reads, kmers, 2, args.max_abund, debugout)
+    if args.gml:
+        networkx.write_gml(graph, args.gml)
+        message = '[kevlar::assemble] graph written to {}'.format(args.gml)
+        print(message, file=args.logfile)
+
+    ccs = list(networkx.connected_components(graph))
+    assert len(ccs) == 1
+
+    assemble_with_greed(reads, kmers, graph, debugout)
 
     contigcount = 0
     unassembledcount = 0

--- a/kevlar/assemble.py
+++ b/kevlar/assemble.py
@@ -19,6 +19,7 @@ except:
 import screed
 import khmer
 import kevlar
+from kevlar.seqio import load_reads_and_kmers
 
 
 def subparser(subparsers):
@@ -29,6 +30,9 @@ def subparser(subparsers):
                            help='output file; default is terminal (stdout)')
     subparser.add_argument('--gml', metavar='FILE',
                            help='write graph to .gml file')
+    subparser.add_argument('-n', '--min-abund', type=int, metavar='N',
+                           default=2, help='discard interesting k-mers that '
+                           'occur fewer than N times')
     subparser.add_argument('-x', '--max-abund', type=int, metavar='X',
                            default=500, help='discard interesting k-mers that '
                            'occur more than X times')
@@ -87,92 +91,6 @@ def merge_and_reannotate(pair, newname):
             newrecord.ikmers.append(ikmer)
 
     return newrecord
-
-
-def load_reads(instream, logstream=None):
-    """
-    Load reads into lookup tables for convenient access.
-
-    The first table is a dictionary of reads indexed by read name, and the
-    second table is a dictionary of read sets indexed by an interesting k-mer.
-    """
-    reads = dict()
-    kmers = defaultdict(set)
-    for n, record in enumerate(kevlar.parse_augmented_fastq(instream), 1):
-        if logstream and n % 10000 == 0:  # pragma: no cover
-            print('[kevlar::assemble]    loaded {:d} reads'.format(n),
-                  file=logstream)
-        reads[record.name] = record
-        for kmer in record.ikmers:
-            kmerseq = kevlar.revcommin(kmer.sequence)
-            kmers[kmerseq].add(record.name)
-    return reads, kmers
-
-
-def graph_init_abund_check_pass(numreads, minkmer, minabund=5, maxabund=500,
-                                logstream=None):
-    """Check whether the k-mer falls within the expected range of abundance."""
-    if maxabund and numreads > maxabund:
-        msg = '            skipping k-mer with abundance {:d}'.format(numreads)
-        print(msg, file=logstream)
-        return False
-    if minabund and numreads < minabund:
-        message = '[kevlar::assemble] WARNING: k-mer {}'.format(minkmer)
-        message += ' (rev. comp. {})'.format(kevlar.revcom(minkmer))
-        message += ' only has abundance {:d}'.format(len(readnames))
-        out = logstream if logstream is not None else sys.stderr
-        print(message, file=out)
-        return False
-    return True
-
-
-def graph_add_edge(graph, pair, minkmer):
-    """
-    Add edge between two nodes in the "shared interesting k-mer" read graph.
-
-    If the edge already exists, make sure that the existing edge matches the
-    edge that would have been added.
-    """
-    tailname, headname = pair.tail.name, pair.head.name
-    if tailname in graph and headname in graph[tailname]:
-        assert graph[tailname][headname]['offset'] == pair.offset
-        if graph[tailname][headname]['tail'] == tailname:
-            assert graph[tailname][headname]['overlap'] == pair.overlap
-        graph[tailname][headname]['ikmers'].add(minkmer)
-    else:
-        graph.add_edge(tailname, headname, offset=pair.offset,
-                       overlap=pair.overlap, ikmers=set([minkmer]),
-                       orient=pair.sameorient, tail=tailname)
-
-
-def graph_init(reads, kmers, minabund=5, maxabund=500, logstream=None):
-    """
-    Initialize the "shared interesting k-mer" read graph.
-
-    Iterate through each interesting k-mer, consider every pair of reads
-    containing that k-mer, and determine whether there should be a edge between
-    the pair of reads in the graph.
-    """
-    graph = networkx.Graph()
-    nkmers = len(kmers)
-    for n, minkmer in enumerate(kmers, 1):
-        if n % 100 == 0:  # pragma: no cover
-            msg = 'processed {:d}/{:d} shared novel k-mers'.format(n, nkmers)
-            print('[kevlar::assemble]    ', msg, sep='', file=logstream)
-
-        readnames = kmers[minkmer]
-        if not graph_init_abund_check_pass(len(readnames), minkmer, minabund,
-                                           maxabund, logstream):
-            continue
-
-        readset = [reads[rn] for rn in readnames]
-        for read1, read2 in itertools.combinations(readset, 2):
-            pair = kevlar.overlap.calc_offset(read1, read2, minkmer, logstream)
-            if pair is kevlar.overlap.INCOMPATIBLE_PAIR:
-                # Shared k-mer but bad overlap
-                continue
-            graph_add_edge(graph, pair, minkmer)
-    return graph
 
 
 def fetch_largest_overlapping_pair(graph, reads):
@@ -255,9 +173,11 @@ def main(args):
     if args.debug:
         debugout = args.logfile
 
-    reads, kmers = load_reads(kevlar.open(args.augfastq, 'r'), debugout)
+    reads, kmers = load_reads_and_kmers(kevlar.open(args.augfastq, 'r'),
+                                        debugout)
     inputreads = list(reads)
-    graph = graph_init(reads, kmers, 2, args.max_abund, debugout)
+    graph = kevlar.overlap.graph_init(reads, kmers, args.min_abund,
+                                      args.max_abund, debugout)
     if args.gml:
         networkx.write_gml(graph, args.gml)
         message = '[kevlar::assemble] graph written to {}'.format(args.gml)

--- a/kevlar/overlap.py
+++ b/kevlar/overlap.py
@@ -31,16 +31,16 @@ def print_read_pair(pair, position, outstream=sys.stderr):
         seq2 = kevlar.revcom(pair.head.sequence)
     ksize = len(pair.head.ikmers[0].sequence)
 
-    details = '--(overlap={:d}, offset={:d}, sameorient={:r})-->'.format(
+    details = '--(overlap={:d}, offset={:d}, sameorient={})-->'.format(
         pair.overlap, pair.offset, pair.sameorient
     )
     info = '[kevlar::overlap] DEBUG: shared interesting k-mer '
     info += '{:s} {:s} {:s}'.format(pair.tail.name, details, pair.head.name)
 
-    print('\n', info, '\n',
-          pair.head.sequence, '\n',
+    print('≠' * 80, '\n', info, '\n', '-' * 80, '\n',
+          pair.tail.sequence, '\n',
           ' ' * position, '|' * ksize, '\n',
-          ' ' * pair.offset, seq2, '\n',
+          ' ' * pair.offset, seq2, '\n', '≠' * 80, '\n',
           sep='', file=outstream)
 
 
@@ -68,7 +68,7 @@ def check_kmer_freq_in_read_pair(read1, read2, minkmer, debugstream=None):
                 )
             )
             print('[kevlar::overlap] INFO', message, file=debugstream)
-            return None, None
+        return None, None
 
     kmer1 = matches1[0]
     kmer2 = matches2[0]
@@ -116,7 +116,7 @@ def validate_read_overlap(tail, head, offset, sameorient, minkmer):
 
     overlap1 = len(segment1)
     overlap2 = len(segment2)
-    if overlap1 != overlap2:
+    if overlap1 != overlap2:  # pragma: no cover
         maxkmer = kevlar.revcom(minkmer)
         print(
             '[kevlar::overlap] ERROR '

--- a/kevlar/overlap.py
+++ b/kevlar/overlap.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 # -----------------------------------------------------------------------------
 # Copyright (c) 2017 The Regents of the University of California

--- a/kevlar/overlap.py
+++ b/kevlar/overlap.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2017 The Regents of the University of California
+#
+# This file is part of kevlar (http://github.com/standage/kevlar) and is
+# licensed under the MIT license: see LICENSE.
+# -----------------------------------------------------------------------------
+
+from __future__ import print_function
+from collections import defaultdict, namedtuple
+import itertools
+import sys
+try:
+    import networkx
+except:
+    pass
+import screed
+import kevlar
+
+
+OverlappingReadPair = namedtuple('OverlappingReadPair',
+                                 'tail head offset overlap sameorient')
+INCOMPATIBLE_PAIR = OverlappingReadPair(None, None, None, None, None)
+
+
+def print_read_pair(pair, position, outstream=sys.stderr):
+    """Convenience print function for debugging."""
+    seq2 = pair.head.sequence
+    if not pair.sameorient:
+        seq2 = kevlar.revcom(pair.head.sequence)
+    ksize = len(pair.head.ikmers[0].sequence)
+
+    details = '--(overlap={:d}, offset={:d}, sameorient={:r})-->'.format(
+        pair.overlap, pair.offset, pair.sameorient
+    )
+    info = '[kevlar::overlap] DEBUG: shared interesting k-mer '
+    info += '{:s} {:s} {:s}'.format(pair.tail.name, details, pair.head.name)
+
+    print('\n', info, '\n',
+          pair.head.sequence, '\n',
+          ' ' * position, '|' * ksize, '\n',
+          ' ' * pair.offset, seq2, '\n',
+          sep='', file=outstream)
+
+
+def check_kmer_freq_in_read_pair(read1, read2, minkmer, debugstream=None):
+    """
+    Check interesting k-mer frequence in each read.
+
+    When calculating offset between a pair of reads, do not use any interesting
+    k-mers that occur multiple times in either read.
+    """
+    maxkmer = kevlar.revcom(minkmer)
+    matches1 = [k for k in read1.ikmers
+                if kevlar.same_seq(k.sequence, minkmer, maxkmer)]
+    matches2 = [k for k in read2.ikmers
+                if kevlar.same_seq(k.sequence, minkmer, maxkmer)]
+    nmatches1 = len(matches1)
+    nmatches2 = len(matches2)
+    assert nmatches1 > 0 and nmatches1 > 0, (nmatches1, nmatches2)
+    if nmatches1 > 1 or nmatches2 > 1:
+        if debugstream:
+            message = (
+                'stubbornly refusing to calculate offset bewteen {:s} and '
+                '{:s}; interesting k-mer {:s} occurs multiple times'.format(
+                    read1.name, read2.name, minkmer
+                )
+            )
+            print('[kevlar::overlap] INFO', message, file=debugstream)
+            return None, None
+
+    kmer1 = matches1[0]
+    kmer2 = matches2[0]
+    return kmer1, kmer2
+
+
+def determine_relative_orientation(read1, read2, kmer1, kmer2):
+    """
+    Determine the relative orientation of a pair of overlapping reads.
+
+    Use the sequence and position of the shared interesting k-mers to determine
+    the read's relative orientation.
+    """
+    ksize = len(kmer1.sequence)
+    pos1 = kmer1.offset
+    pos2 = kmer2.offset
+    sameorient = True
+    if kmer1.sequence != kmer2.sequence:
+        assert kmer1.sequence == kevlar.revcom(kmer2.sequence)
+        sameorient = False
+        pos2 = len(read2.sequence) - (kmer2.offset + ksize)
+
+    tail, head = read1, read2
+    tailpos, headpos = pos1, pos2
+    read1contained = pos1 == pos2 and len(read2.sequence) > len(read1.sequence)
+    if pos2 > pos1 or read1contained:
+        tail, head = read2, read1
+        tailpos, headpos = headpos, tailpos
+    offset = tailpos - headpos
+
+    return tail, head, offset, sameorient, tailpos
+
+
+def validate_read_overlap(tail, head, offset, sameorient, minkmer):
+    """Verify that the overlap between two read is identical."""
+    headseq = head.sequence if sameorient else kevlar.revcom(head.sequence)
+    seg2offset = len(head.sequence) - len(tail.sequence) + offset
+    if offset + len(headseq) <= len(tail.sequence):
+        segment1 = tail.sequence[offset:offset+len(headseq)]
+        segment2 = headseq
+        seg2offset = None
+    else:
+        segment1 = tail.sequence[offset:]
+        segment2 = headseq[:-seg2offset]
+
+    overlap1 = len(segment1)
+    overlap2 = len(segment2)
+    if overlap1 != overlap2:
+        maxkmer = kevlar.revcom(minkmer)
+        print(
+            '[kevlar::overlap] ERROR '
+            'tail="{tail}" head="{head}" offset={offset} altoffset={altoffset}'
+            ' tailoverlap={overlap} headoverlap={headover} tailolvp={tailseq}'
+            ' headolvp={headseq} kmer={minkmer},{maxkmer} tailseq={tailread}'
+            ' headseq={headread}'.format(
+                tail=tail.name, head=tail.name,
+                offset=offset,
+                altoffset=seg2offset,
+                overlap=overlap1, headover=len(segment2),
+                tailseq=segment1, headseq=segment2,
+                minkmer=minkmer, maxkmer=maxkmer,
+                tailread=tail.sequence, headread=head.sequence,
+            ), file=sys.stderr
+        )
+    assert overlap1 == overlap2
+    if segment1 != segment2:
+        return None
+    return overlap1
+
+
+def calc_offset(read1, read2, minkmer, debugstream=None):
+    """
+    Calculate offset between reads that share an interesting k-mer.
+
+    Each read is annotated with its associated interesting k-mers. These are
+    used to bait pairs of reads sharing interesting k-mers to build a graph of
+    shared interesting k-mers. Given a pair of reads sharing an interesting,
+    k-mer calculate the offset between them and determine whether they are in
+    the same orientation. Any mismatches between the aligned reads (outside the
+    shared k-mer) will render the offset invalid.
+    """
+    kmer1, kmer2 = check_kmer_freq_in_read_pair(read1, read2, minkmer,
+                                                debugstream)
+    if kmer1 is None or kmer2 is None:
+        return INCOMPATIBLE_PAIR
+
+    tail, head, offset, sameorient, tailpos = determine_relative_orientation(
+        read1, read2, kmer1, kmer2
+    )
+
+    overlap = validate_read_overlap(tail, head, offset, sameorient, minkmer)
+    if overlap is None:
+        return INCOMPATIBLE_PAIR
+
+    pair = OverlappingReadPair(tail=tail, head=head, offset=offset,
+                               overlap=overlap, sameorient=sameorient)
+    if debugstream:
+        print_read_pair(pair, tailpos, debugstream)
+
+    return pair

--- a/kevlar/overlap.py
+++ b/kevlar/overlap.py
@@ -103,7 +103,7 @@ def determine_relative_orientation(read1, read2, kmer1, kmer2):
 
 
 def validate_read_overlap(tail, head, offset, sameorient, minkmer):
-    """Verify that the overlap between two read is identical."""
+    """Verify that the overlap between two reads is identical."""
     headseq = head.sequence if sameorient else kevlar.revcom(head.sequence)
     seg2offset = len(head.sequence) - len(tail.sequence) + offset
     if offset + len(headseq) <= len(tail.sequence):

--- a/kevlar/seqio.py
+++ b/kevlar/seqio.py
@@ -85,6 +85,26 @@ def print_augmented_fastq(record, outstream=stdout):
               sep='', file=outstream)
 
 
+def load_reads_and_kmers(instream, logstream=None):
+    """
+    Load reads into lookup tables for convenient access.
+
+    The first table is a dictionary of reads indexed by read name, and the
+    second table is a dictionary of read sets indexed by an interesting k-mer.
+    """
+    reads = dict()
+    kmers = defaultdict(set)
+    for n, record in enumerate(kevlar.parse_augmented_fastq(instream), 1):
+        if logstream and n % 10000 == 0:  # pragma: no cover
+            print('[kevlar::assemble]    loaded {:d} reads'.format(n),
+                  file=logstream)
+        reads[record.name] = record
+        for kmer in record.ikmers:
+            kmerseq = kevlar.revcommin(kmer.sequence)
+            kmers[kmerseq].add(record.name)
+    return reads, kmers
+
+
 class AnnotatedReadSet(object):
     """
     Data structure for de-duplicating reads and combining annotated k-mers.

--- a/kevlar/tests/test_assemble.py
+++ b/kevlar/tests/test_assemble.py
@@ -12,10 +12,10 @@ import screed
 from networkx import connected_components
 import kevlar
 from kevlar import KmerOfInterest
-from kevlar.assemble import (merge_pair, merge_and_reannotate, load_reads,
-                             graph_init)
+from kevlar.seqio import load_reads_and_kmers
+from kevlar.assemble import (merge_pair, merge_and_reannotate)
 from kevlar.overlap import (OverlappingReadPair, INCOMPATIBLE_PAIR,
-                            calc_offset)
+                            calc_offset, graph_init)
 from kevlar.tests import data_file
 
 
@@ -364,10 +364,10 @@ def test_merge_contained_with_offset_and_error(record7, record12):
     assert 'attempted to assemble incompatible reads' in str(ae)
 
 
-def test_load_reads():
+def test_load_reads_and_kmers():
     """Make sure augmented records are loaded correctly."""
     instream = open(data_file('var1.reads.augfastq'), 'r')
-    reads, kmers = load_reads(instream, logstream=None)
+    reads, kmers = load_reads_and_kmers(instream, logstream=None)
     assert len(reads) == 10
     assert len(kmers) == 7
 
@@ -389,7 +389,7 @@ def test_load_reads():
 def test_graph_init():
     """Test graph initialization."""
     instream = open(data_file('var1.reads.augfastq'), 'r')
-    reads, kmers = load_reads(instream, logstream=None)
+    reads, kmers = load_reads_and_kmers(instream, logstream=None)
     graph = graph_init(reads, kmers, maxabund=None, logstream=None)
 
     # 10 reads in the file, but read16f has no valid connections due to error
@@ -420,7 +420,7 @@ def test_graph_init():
 
 def test_assembly_round2():
     instream = open(data_file('var1.round2.augfastq'), 'r')
-    reads, kmers = load_reads(instream, logstream=None)
+    reads, kmers = load_reads_and_kmers(instream, logstream=None)
     contig, read = reads['contig1'], reads['read22f start=5,mutations=0']
     pair = calc_offset(contig, read, 'AAGTCTCGACTTTAAGGAAGTGGGCCTAC')
     assert pair.tail == read
@@ -432,7 +432,7 @@ def test_assembly_round2():
 
 def test_assembly_contigs():
     instream = open(data_file('AluContigs.augfastq'), 'r')
-    reads, kmers = load_reads(instream, logstream=None)
+    reads, kmers = load_reads_and_kmers(instream, logstream=None)
     contig6, contig7 = reads['contig6'], reads['contig7']
     pair = calc_offset(contig6, contig7, 'AAAGTTTTCTTAAAAACATATATGGCCGGGC')
     assert pair.offset == 50

--- a/kevlar/tests/test_assemble.py
+++ b/kevlar/tests/test_assemble.py
@@ -12,8 +12,10 @@ import screed
 from networkx import connected_components
 import kevlar
 from kevlar import KmerOfInterest
-from kevlar.assemble import (merge_pair, merge_and_reannotate, calc_offset,
-                             OverlappingReadPair, load_reads, graph_init)
+from kevlar.assemble import (merge_pair, merge_and_reannotate, load_reads,
+                             graph_init)
+from kevlar.overlap import (OverlappingReadPair, INCOMPATIBLE_PAIR,
+                            calc_offset)
 from kevlar.tests import data_file
 
 
@@ -164,72 +166,6 @@ def record12():
         sequence='CCCGGATACTTGAAGCAGGCAcC',
         ikmers=[KmerOfInterest('CCCGGATACTTGAAGCA', 0, [21, 0, 0])],
     )
-
-
-def test_calc_offset_same_orientation(record1, record2):
-    """
-    Compute offset of reads sharing an interesting k-mer, same orientation.
-
-    GCTGCACCGATGTACGCAAA
-                  |||||
-                 ACGCAAAGCTATTTAAAACC
-    """
-    pair = kevlar.assemble.calc_offset(record1, record2, 'CGCAA')
-    assert pair.tail == record1
-    assert pair.head == record2
-    assert pair.offset == 13
-    assert pair.overlap == 7
-    assert pair.sameorient is True
-
-
-def test_calc_offset_opposite_orientation(record1, record3):
-    """
-    Compute offset of reads sharing an interesting k-mer, opposite orientation.
-
-    GCTGCACCGATGTACGCAAA
-                  |||||
-                 ACGCAAAGCTATTTAAAACC <-- reverse complement
-    """
-    pair = kevlar.assemble.calc_offset(record1, record3, 'CGCAA')
-    assert pair.tail == record1
-    assert pair.head == record3
-    assert pair.offset == 13
-    assert pair.overlap == 7
-    assert pair.sameorient is False
-
-
-def test_calc_offset_mismatch(record1, record4):
-    """
-    Compute offset of reads sharing an interesting k-mer, but with mismatch.
-
-    GCTGCACCGATGTACGCAAA
-                  |||||X
-                 ACGCAATGCTATTTAAAACC
-
-    The interesting k-mer is simply a seed. The assembler requires that the
-    entire overlap between the two reads matches exactly, so the mismatch here
-    should return a null offset indicating that the pair of reads is
-    incompatible despite sharing an interesting k-mer.
-    """
-    pair = kevlar.assemble.calc_offset(record1, record4, 'CGCAA')
-    assert pair == kevlar.assemble.IncompatiblePair
-
-
-def test_calc_offset_weirdness(record5, record6):
-    """
-    Compute offset of reads sharing an interesting k-mer, but with mismatches.
-
-    CTCTTCCGGCAGTCACTGTCAAGAGAGGGTGAACT
-                   |||||||
-                    |||||||     XXXXXXX
-                TCACTGTCAAGAGAGGCCTACGGATTCGGTTACTG
-
-    Not just a single mismatch, but extensive differences making the reads
-    incompatible for assembly.
-    """
-    for ikmer in ['CTGTCAA', 'TGTCAAG']:
-        pair = kevlar.assemble.calc_offset(record5, record6, ikmer)
-        assert pair == kevlar.assemble.IncompatiblePair
 
 
 def test_merge_pair(record1, record2, record4):
@@ -419,7 +355,7 @@ def test_merge_contained_with_offset_and_error(record7, record12):
               |||||||||||||||||    *
     """
     pair = calc_offset(record7, record12, 'CCCGGATACTTGAAGCA')
-    assert pair == kevlar.assemble.IncompatiblePair
+    assert pair == INCOMPATIBLE_PAIR
 
     pair = OverlappingReadPair(tail=record7, head=record12, offset=10,
                                overlap=23, sameorient=True)

--- a/kevlar/tests/test_overlap.py
+++ b/kevlar/tests/test_overlap.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2017 The Regents of the University of California
+#
+# This file is part of kevlar (http://github.com/standage/kevlar) and is
+# licensed under the MIT license: see LICENSE.
+# -----------------------------------------------------------------------------
+
+import pytest
+import screed
+import kevlar
+from kevlar import KmerOfInterest
+from kevlar.overlap import (calc_offset, OverlappingReadPair,
+                            INCOMPATIBLE_PAIR)
+
+
+@pytest.fixture
+def record1():
+    return screed.Record(
+        name='read1',
+        sequence='GCTGCACCGATGTACGCAAA',
+        ikmers=[KmerOfInterest('CGCAA', 14, [15, 0, 0])],
+    )
+
+
+@pytest.fixture
+def record2():
+    return screed.Record(
+        name='read2',
+        sequence='ACGCAAAGCTATTTAAAACC',
+        ikmers=[
+            KmerOfInterest('CGCAA', 1, [15, 0, 0]),
+            KmerOfInterest('AAAAC', 14, [19, 1, 0]),
+        ],
+    )
+
+
+@pytest.fixture
+def record3():
+    # reverse complement of record2
+    return screed.Record(
+        name='read3',
+        sequence='GGTTTTAAATAGCTTTGCGT',
+        ikmers=[
+            KmerOfInterest('GTTTT', 1, [19, 1, 0]),
+            KmerOfInterest('TTGCG', 14, [15, 0, 0]),
+        ],
+    )
+
+
+@pytest.fixture
+def record4():
+    # similar to record2 but with a single nucleotide mismatch
+    return screed.Record(
+        name='read4',
+        sequence='ACGCAATGCTATTTAAAACC',
+        ikmers=[
+            KmerOfInterest('CGCAA', 1, [15, 0, 0]),
+            KmerOfInterest('AAAAC', 14, [19, 1, 0]),
+        ],
+    )
+
+
+@pytest.fixture
+def record5():
+    return screed.Record(
+        name='read5',
+        sequence='CTCTTCCGGCAGTCACTGTCAAGAGAGGGTGAACT',
+        ikmers=[
+            KmerOfInterest('CTGTCAA', 15, [12, 0, 0]),
+            KmerOfInterest('TGTCAAG', 16, [13, 0, 0]),
+        ],
+    )
+
+
+@pytest.fixture
+def record6():
+    return screed.Record(
+        name='read6',
+        sequence='TCACTGTCAAGAGAGGCCTACGGATTCGGTTACTG',
+        ikmers=[
+            KmerOfInterest('CTGTCAA', 3, [12, 0, 0]),
+            KmerOfInterest('TGTCAAG', 4, [13, 0, 0]),
+        ],
+    )
+
+
+def test_calc_offset_same_orientation(record1, record2):
+    """
+    Compute offset of reads sharing an interesting k-mer, same orientation.
+
+    GCTGCACCGATGTACGCAAA
+                  |||||
+                 ACGCAAAGCTATTTAAAACC
+    """
+    pair = kevlar.overlap.calc_offset(record1, record2, 'CGCAA')
+    assert pair.tail == record1
+    assert pair.head == record2
+    assert pair.offset == 13
+    assert pair.overlap == 7
+    assert pair.sameorient is True
+
+
+def test_calc_offset_opposite_orientation(record1, record3):
+    """
+    Compute offset of reads sharing an interesting k-mer, opposite orientation.
+
+    GCTGCACCGATGTACGCAAA
+                  |||||
+                 ACGCAAAGCTATTTAAAACC <-- reverse complement
+    """
+    pair = kevlar.overlap.calc_offset(record1, record3, 'CGCAA')
+    assert pair.tail == record1
+    assert pair.head == record3
+    assert pair.offset == 13
+    assert pair.overlap == 7
+    assert pair.sameorient is False
+
+
+def test_calc_offset_mismatch(record1, record4):
+    """
+    Compute offset of reads sharing an interesting k-mer, but with mismatch.
+
+    GCTGCACCGATGTACGCAAA
+                  |||||X
+                 ACGCAATGCTATTTAAAACC
+
+    The interesting k-mer is simply a seed. The assembler requires that the
+    entire overlap between the two reads matches exactly, so the mismatch here
+    should return a null offset indicating that the pair of reads is
+    incompatible despite sharing an interesting k-mer.
+    """
+    pair = kevlar.overlap.calc_offset(record1, record4, 'CGCAA')
+    assert pair == kevlar.overlap.INCOMPATIBLE_PAIR
+
+
+def test_calc_offset_weirdness(record5, record6):
+    """
+    Compute offset of reads sharing an interesting k-mer, but with mismatches.
+
+    CTCTTCCGGCAGTCACTGTCAAGAGAGGGTGAACT
+                   |||||||
+                    |||||||     XXXXXXX
+                TCACTGTCAAGAGAGGCCTACGGATTCGGTTACTG
+
+    Not just a single mismatch, but extensive differences making the reads
+    incompatible for assembly.
+    """
+    for ikmer in ['CTGTCAA', 'TGTCAAG']:
+        pair = kevlar.overlap.calc_offset(record5, record6, ikmer)
+        assert pair == kevlar.overlap.INCOMPATIBLE_PAIR


### PR DESCRIPTION
Both the `partition` functionality (currently part of `filter` command) and the `assemble` functionality depend on computing overlaps between reads. The partition functionality can only group by shared k-mer at the moment, but we want the option to partition using the stricter criterion used in assembly (perfect agreement in the overlap).

This PR is refactoring the existing code to make it more accessible and reusable.