### PR TITLE
Fix issue with overlap/swap/orientation

### DIFF
--- a/kevlar/assemble.py
+++ b/kevlar/assemble.py
@@ -168,6 +168,13 @@ def main(args):
 
     graph = kevlar.overlap.graph_init_strict(reads, kmers, args.min_abund,
                                              args.max_abund, debugout)
+    message = 'initialized "shared interesting k-mers" graph'
+    message += ' with {:d} nodes'.format(graph.number_of_nodes())
+    message += ' and {:d} edges'.format(graph.number_of_edges())
+    # If number of nodes is less than number of reads, it's probably because
+    # some reads have no valid overlaps with other reads.
+    print('[kevlar::assemble]', message, file=args.logfile)
+
     if args.gml:
         tempgraph = graph.copy()
         for n1, n2 in tempgraph.edges():

--- a/kevlar/assemble.py
+++ b/kevlar/assemble.py
@@ -39,8 +39,6 @@ def merge_pair(pair):
     headindex = len(tailseq) - offset
     headsuffix = headseq[headindex:]
     tailprefix = tailseq[offset:offset+pair.overlap]
-    #print('DEBUG\n    ', tailprefix, '\n    ', headseq[:headindex], '\n', sep='', file=sys.stderr)
-    #print('DEBUG\n    ', tailseq, '\n    ', headseq, '\n', sep='', file=sys.stderr)
     assert tailprefix == headseq[:headindex], \
         'error: attempted to assemble incompatible reads'
 

--- a/kevlar/tests/test_assemble.py
+++ b/kevlar/tests/test_assemble.py
@@ -177,11 +177,11 @@ def test_merge_pair(record1, record2, record4):
                  ACGCAAAGCTATTTAAAACC
     """
     pair = OverlappingReadPair(tail=record1, head=record2, offset=13,
-                               overlap=7, sameorient=True)
+                               overlap=7, sameorient=True, swapped=False)
     assert merge_pair(pair) == 'GCTGCACCGATGTACGCAAAGCTATTTAAAACC'
 
     pair = OverlappingReadPair(tail=record1, head=record4, offset=13,
-                               overlap=7, sameorient=True)
+                               overlap=7, sameorient=True, swapped=False)
     with pytest.raises(AssertionError) as ae:
         contig = merge_pair(pair)
     assert 'attempted to assemble incompatible reads' in str(ae)
@@ -196,7 +196,7 @@ def test_merge_and_reannotate_same_orientation(record1, record2):
                  ACGCAAAGCTATTTAAAACC                       *****        *****
     """
     pair = OverlappingReadPair(tail=record1, head=record2, offset=13,
-                               overlap=7, sameorient=True)
+                               overlap=7, sameorient=True, swapped=False)
     newrecord = merge_and_reannotate(pair, 'contig1')
     assert newrecord.name == 'contig1'
     assert newrecord.sequence == 'GCTGCACCGATGTACGCAAAGCTATTTAAAACC'
@@ -214,7 +214,7 @@ def test_merge_and_reannotate_opposite_orientation(record1, record3):
                  ACGCAAAGCTATTTAAAACC                       *****        *****
     """
     pair = OverlappingReadPair(tail=record1, head=record3, offset=13,
-                               overlap=7, sameorient=False)
+                               overlap=7, sameorient=False, swapped=False)
     newrecord = merge_and_reannotate(pair, 'contig1')
     assert newrecord.name == 'contig1'
     assert newrecord.sequence == 'GCTGCACCGATGTACGCAAAGCTATTTAAAACC'
@@ -241,7 +241,7 @@ def test_merge_and_reannotate_edge_case_same_orientation(record7, record8):
                                                                                       |||||||||||||||||
     """  # noqa
     pair = OverlappingReadPair(tail=record7, head=record8, offset=39,
-                               overlap=21, sameorient=True)
+                               overlap=21, sameorient=True, swapped=False)
     newrecord = merge_and_reannotate(pair, 'SoMeCoNtIg')
     assert newrecord.name == 'SoMeCoNtIg'
     assert newrecord.sequence == ('CAGGTCCCCACCCGGATACTTGAAGCAGGCAGCCTCAAGGTAT'
@@ -277,7 +277,7 @@ def test_merge_and_reannotate_edge_case_opposite_orientation(record7, record9):
                                                                                       |||||||||||||||||
     """  # noqa
     pair = OverlappingReadPair(tail=record7, head=record9, offset=39,
-                               overlap=21, sameorient=False)
+                               overlap=21, sameorient=False, swapped=False)
     newrecord = merge_and_reannotate(pair, 'SoMeCoNtIg')
     assert newrecord.name == 'SoMeCoNtIg'
     assert newrecord.sequence == ('CAGGTCCCCACCCGGATACTTGAAGCAGGCAGCCTCAAGGTAT'
@@ -312,7 +312,7 @@ def test_merge_and_reannotate_contained(record7, record10):
               |||||||||||||||||
     """
     pair = OverlappingReadPair(tail=record7, head=record10, offset=0,
-                               overlap=35, sameorient=True)
+                               overlap=35, sameorient=True, swapped=False)
     newrecord = merge_and_reannotate(pair, 'ContainedAtOne')
     assert newrecord.name == 'ContainedAtOne'
     assert newrecord.sequence == record7.sequence
@@ -334,7 +334,7 @@ def test_merge_and_reannotate_contained_with_offset(record7, record11):
               |||||||||||||||||
     """
     pair = OverlappingReadPair(tail=record7, head=record11, offset=10,
-                               overlap=23, sameorient=True)
+                               overlap=23, sameorient=True, swapped=False)
     newrecord = merge_and_reannotate(pair, 'ContainedAtOffset')
     assert newrecord.sequence == record7.sequence
     assert newrecord.ikmers == record7.ikmers
@@ -358,7 +358,7 @@ def test_merge_contained_with_offset_and_error(record7, record12):
     assert pair == INCOMPATIBLE_PAIR
 
     pair = OverlappingReadPair(tail=record7, head=record12, offset=10,
-                               overlap=23, sameorient=True)
+                               overlap=23, sameorient=True, swapped=False)
     with pytest.raises(AssertionError) as ae:
         newrecord = merge_and_reannotate(pair, 'WontWork')
     assert 'attempted to assemble incompatible reads' in str(ae)
@@ -412,7 +412,10 @@ def test_graph_init():
     r37name = 'read37f start=9,mutations=0'
     assert graph[r37name][r8name]['offset'] == 1
     assert graph[r37name][r8name]['overlap'] == 99
-    pair = OverlappingReadPair(reads[r8name], reads[r37name], 1, 99, True)
+    pair = OverlappingReadPair(
+        tail=reads[r8name], head=reads[r37name], offset=1, overlap=99,
+        sameorient=True, swapped=False
+    )
     assert merge_pair(pair) == ('CACTGTCCTTACAGGTGGATAGTCGCTTTGTAATAAAAGAGTTAC'
                                 'ACCCCGGTTTTTAGAAGTCTCGACTTTAAGGAAGTGGGCCTACGG'
                                 'CGGAAGCCGTC')

--- a/kevlar/tests/test_overlap.py
+++ b/kevlar/tests/test_overlap.py
@@ -98,6 +98,52 @@ def record6():
         ],
     )
 
+@pytest.fixture
+def picorecord1():
+    return screed.Record(
+        name='seq1_901350_901788_1:0:0_0:0:0_21ca1/2',
+        sequence=('GTTTTTTTTTTGTTTCCCAAAGTAAGGCTGAGTGAACAATATTTTCTCATAGTTTTGAC'
+                  'AAAAACAAAGGAATCCTTAGTTATTAAACTCGGGAGTTTGA'),
+        ikmers=[
+            KmerOfInterest('TTTTTTGTTTCCCAAAGTAAGGCTG', 5, [19, 0, 0]),
+            KmerOfInterest('TTTTTGTTTCCCAAAGTAAGGCTGA', 6, [18, 1, 0]),
+            KmerOfInterest('TTTTGTTTCCCAAAGTAAGGCTGAG', 7, [18, 1, 0]),
+            KmerOfInterest('TTTGTTTCCCAAAGTAAGGCTGAGT', 8, [18, 0, 0]),
+            KmerOfInterest('TTGTTTCCCAAAGTAAGGCTGAGTG', 9, [17, 0, 0]),
+        ],
+    )
+
+
+@pytest.fixture
+def picorecord2():
+    return screed.Record(
+        name='seq1_901428_901847_3:0:0_0:0:0_87d/1',
+        sequence=('TTACATTTATTCGTTTGTGCAGGCTGAGACCTCACTTCCAACTGTAATCCAAAAGCTTA'
+                  'GTTTTTTTTTTGTTTCCCAAAGTAAGGCTGAGTGAACAATA'),
+        ikmers=[
+            KmerOfInterest('TTTTTTGTTTCCCAAAGTAAGGCTG', 64, [19, 0, 0]),
+            KmerOfInterest('TTTTTGTTTCCCAAAGTAAGGCTGA', 65, [18, 1, 0]),
+            KmerOfInterest('TTTTGTTTCCCAAAGTAAGGCTGAG', 66, [18, 1, 0]),
+            KmerOfInterest('TTTGTTTCCCAAAGTAAGGCTGAGT', 67, [18, 0, 0]),
+            KmerOfInterest('TTGTTTCCCAAAGTAAGGCTGAGTG', 68, [17, 0, 0]),
+        ],
+    )
+
+@pytest.fixture
+def picorecord3():
+    return screed.Record(
+        name='seq1_901428_901847_3:0:0_0:0:0_87d/1',
+        sequence=('TATTGTTCACTCAGCCTTACTTTGGGAAACAAAAAAAAAACTAAGCTTTTGGATTACAG'
+                  'TTGGAAGTGAGGTCTCAGCCTGCACAAACGAATAAATGTAA'),
+        ikmers=[
+            KmerOfInterest('CAGCCTTACTTTGGGAAACAAAAAA', 11, [17, 0, 0]),
+            KmerOfInterest('TCAGCCTTACTTTGGGAAACAAAAA', 10, [18, 0, 0]),
+            KmerOfInterest('CTCAGCCTTACTTTGGGAAACAAAA', 9, [18, 1, 0]),
+            KmerOfInterest('ACTCAGCCTTACTTTGGGAAACAAA', 8, [18, 1, 0]),
+            KmerOfInterest('CACTCAGCCTTACTTTGGGAAACAA', 7, [19, 0, 0]),
+        ],
+    )
+
 
 def test_print_read_pair_same_orient(record1, record2, capsys):
     pair = kevlar.overlap.calc_offset(record1, record2, 'CGCAA')
@@ -202,3 +248,30 @@ def test_calc_offset_weirdness(record5, record6):
     for ikmer in ['CTGTCAA', 'TGTCAAG']:
         pair = kevlar.overlap.calc_offset(record5, record6, ikmer)
         assert pair == INCOMPATIBLE_PAIR
+
+
+def test_pico_offset(picorecord1, picorecord2, picorecord3):
+    pair = kevlar.overlap.calc_offset(picorecord1, picorecord2,
+                                      'TTTTTTGTTTCCCAAAGTAAGGCTG')
+    assert pair.offset == 59
+    assert pair.head.name == 'seq1_901350_901788_1:0:0_0:0:0_21ca1/2'
+    contig = kevlar.assemble.merge_pair(pair)
+    print(contig)
+
+    k1, k3 = kevlar.overlap.check_kmer_freq_in_read_pair(picorecord1, picorecord3, 'TTTTTTGTTTCCCAAAGTAAGGCTG')
+    assert k1.offset == 5
+    assert k3.offset == 11
+    tail, head, offset, sameorient, tailpos = kevlar.overlap.determine_relative_orientation(picorecord1, picorecord3, k1, k3)
+    assert head.name == 'seq1_901350_901788_1:0:0_0:0:0_21ca1/2'
+    assert offset == 59
+    assert sameorient is False
+    assert tailpos == 64
+    overlap = kevlar.overlap.validate_read_overlap(tail, head, offset, sameorient, 'TTTTTTGTTTCCCAAAGTAAGGCTG', True)
+    print(overlap)
+
+    pair = kevlar.overlap.calc_offset(picorecord1, picorecord3,
+                                      'TTTTTTGTTTCCCAAAGTAAGGCTG')
+    assert pair.head.name == 'seq1_901350_901788_1:0:0_0:0:0_21ca1/2'
+    contig = kevlar.assemble.merge_pair(pair)
+    print(contig)
+    assert False

--- a/kevlar/tests/test_overlap.py
+++ b/kevlar/tests/test_overlap.py
@@ -98,6 +98,7 @@ def record6():
         ],
     )
 
+
 @pytest.fixture
 def picorecord1():
     return screed.Record(
@@ -128,6 +129,7 @@ def picorecord2():
             KmerOfInterest('TTGTTTCCCAAAGTAAGGCTGAGTG', 68, [17, 0, 0]),
         ],
     )
+
 
 @pytest.fixture
 def picorecord3():
@@ -255,23 +257,15 @@ def test_pico_offset(picorecord1, picorecord2, picorecord3):
                                       'TTTTTTGTTTCCCAAAGTAAGGCTG')
     assert pair.offset == 59
     assert pair.head.name == 'seq1_901350_901788_1:0:0_0:0:0_21ca1/2'
+    assert pair.swapped is False
     contig = kevlar.assemble.merge_pair(pair)
     print(contig)
-
-    k1, k3 = kevlar.overlap.check_kmer_freq_in_read_pair(picorecord1, picorecord3, 'TTTTTTGTTTCCCAAAGTAAGGCTG')
-    assert k1.offset == 5
-    assert k3.offset == 11
-    tail, head, offset, sameorient, tailpos = kevlar.overlap.determine_relative_orientation(picorecord1, picorecord3, k1, k3)
-    assert head.name == 'seq1_901350_901788_1:0:0_0:0:0_21ca1/2'
-    assert offset == 59
-    assert sameorient is False
-    assert tailpos == 64
-    overlap = kevlar.overlap.validate_read_overlap(tail, head, offset, sameorient, 'TTTTTTGTTTCCCAAAGTAAGGCTG', True)
-    print(overlap)
 
     pair = kevlar.overlap.calc_offset(picorecord1, picorecord3,
                                       'TTTTTTGTTTCCCAAAGTAAGGCTG')
+    assert pair.offset == 59
     assert pair.head.name == 'seq1_901350_901788_1:0:0_0:0:0_21ca1/2'
-    contig = kevlar.assemble.merge_pair(pair)
-    print(contig)
-    assert False
+    assert pair.swapped is True
+    newcontig = kevlar.assemble.merge_pair(pair)
+    print(newcontig)
+    assert kevlar.same_seq(contig, newcontig)


### PR DESCRIPTION
The "strict overlap" code was failing to find valid overlaps in certain scenarios, specifically when the "tail" and "head" reads were swapped compared to the input order and when they had different orientations. This led to missing edges in the "group reads by shared k-mers" graph used for variant assembly. This error went unobserved for a while since the code logic treated these as "incompatible overlaps" (such as when there's a sequencing error in the overlap between two reads, outside of the seed k-mer). Fortunately, there haven't been any extra edges.

This PR fixes the issue and adds a regression test.