### PR TITLE
More documentation

### DIFF
--- a/kevlar/cli/assemble.py
+++ b/kevlar/cli/assemble.py
@@ -9,7 +9,11 @@
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('assemble')
+    """Define the `kevlar assemble` command-line interface."""
+
+    desc = "Use a simple greedy algorithm to assemble a single variant's reads"
+
+    subparser = subparsers.add_parser('assemble', description=desc)
     subparser.add_argument('-d', '--debug', action='store_true',
                            help='print debugging output')
     subparser.add_argument('-o', '--out', metavar='FILE',

--- a/kevlar/cli/call.py
+++ b/kevlar/cli/call.py
@@ -9,7 +9,14 @@
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('call', add_help=False)
+    """Define the `kevlar call` command-line interface."""
+
+    desc = """\
+    Align variant-related reads to the reference genome and call the variant
+    from the alignment.
+    """
+
+    subparser = subparsers.add_parser('call', description=desc, add_help=False)
     subparser._positionals.title = 'Required inputs'
 
     score_args = subparser.add_argument_group('Alignment scoring')

--- a/kevlar/cli/collect.py
+++ b/kevlar/cli/collect.py
@@ -13,6 +13,8 @@ from khmer import khmer_args
 
 
 def subparser(subparsers):
+    """Define the `kevlar collect` command-line interface."""
+
     subparser = subparsers.add_parser('collect')
     subparser.add_argument('-d', '--debug', action='store_true',
                            help='print debugging output')

--- a/kevlar/cli/dump.py
+++ b/kevlar/cli/dump.py
@@ -12,7 +12,11 @@ from khmer import khmer_args
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('dump')
+    """Define the `kevlar dump` command-line interface."""
+
+    desc = 'Discard reads that align perfectly to the reference genome.'
+
+    subparser = subparsers.add_parser('dump', description=desc)
     subparser.add_argument('--seqid', metavar='SEQ',
                            help='dump reads not mapped to SEQ')
     subparser.add_argument('--genomemask', metavar='FILE', help='dump reads '

--- a/kevlar/cli/filter.py
+++ b/kevlar/cli/filter.py
@@ -12,7 +12,15 @@ from khmer import khmer_args
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('filter', add_help=False)
+    """Define the `kevlar filter` command-line interface."""
+
+    desc = """\
+    Discard k-mers and reads that are contaminant in origin or whose abundances
+    were inflated at the "kevlar count" or "kevlar novel" stage.
+    """
+
+    subparser = subparsers.add_parser('filter', description=desc,
+                                      add_help=False)
     subparser._positionals.title = 'Required inputs'
 
     refr_args = subparser.add_argument_group(

--- a/kevlar/cli/localize.py
+++ b/kevlar/cli/localize.py
@@ -9,7 +9,16 @@
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('localize')
+    """Define the `kevlar localize` command-line interface."""
+
+    desc = """\
+    Given a reference genome and a contig (or set of contigs) assembled from
+    variant-related reads, retrieve the portion of the reference genome
+    corresponding to the variant. NOTE: this command relies on the `bwa`
+    program being in the PATH environmental variable.
+    """
+
+    subparser = subparsers.add_parser('localize', description=desc)
     subparser.add_argument('-x', '--max-diff', type=int, metavar='X',
                            default=1000, help='span of all k-mer starting '
                            'positions should not exceed X bp')

--- a/kevlar/cli/mutate.py
+++ b/kevlar/cli/mutate.py
@@ -9,7 +9,11 @@
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('mutate')
+    """Define the `kevlar mutate` command-line interface."""
+
+    desc = 'Apply the specified mutations to the genome provided.'
+
+    subparser = subparsers.add_parser('mutate', description=desc)
     subparser.add_argument('-o', '--out', metavar='FILE',
                            help='output file; default is terminal (stdout)')
     subparser.add_argument('mutations', help='mutations file')

--- a/kevlar/cli/partition.py
+++ b/kevlar/cli/partition.py
@@ -9,7 +9,17 @@
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('partition')
+    """Define the `kevlar novel` command-line interface."""
+
+    desc = """\
+    Construct a graph to group reads by shared interesting k-mers. Nodes in the
+    graph represent reads, and edges between a pair of nodes indicate that the
+    two corresponding reads have one or more interesting k-mers in common.
+    Connected components in the undirected graph correspond to distinct
+    variants (or variant-related breakpoints).
+    """
+
+    subparser = subparsers.add_parser('partition', description=desc)
     subparser.add_argument('-d', '--debug', action='store_true',
                            help='print debugging output')
     subparser.add_argument('-s', '--strict', action='store_true',

--- a/kevlar/cli/reaugment.py
+++ b/kevlar/cli/reaugment.py
@@ -9,7 +9,17 @@
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('reaugment')
+    """Define the `kevlar reaugment` command-line interface."""
+
+    desc = """\
+    Internally, kevlar uses an "augmented" Fastq format for storing "interesing
+    k-mers" and the reads that contain them. Integrating kevlar with other
+    tools, however, requires discarding this extra information. The "kevlar
+    reaugment" command is used to re-annotate interesting k-mers in Fastq
+    files where the information has been stripped.
+    """
+
+    subparser = subparsers.add_parser('reaugment', description=desc)
     subparser.add_argument('-o', '--out', metavar='FILE',
                            help='output file; default is terminal (stdout)')
     subparser.add_argument('augfastq', help='original augmented Fastq file')

--- a/kevlar/novel.py
+++ b/kevlar/novel.py
@@ -22,6 +22,13 @@ class KevlarCaseSampleMismatchError(ValueError):
 
 def kmer_is_interesting(kmer, casecounts, controlcounts, case_min=5,
                         ctrl_max=1):
+    """
+    Well, is it?
+
+    Consult the k-mer's abundance in each sample to determine whether it is
+    "interesting". It must be >= `case_min` in each of `casecounts`, and must
+    be <= `ctrl_max` in each of `controlcounts`.
+    """
     caseabunds = list()
     for ct in casecounts:
         abund = ct.get(kmer)

--- a/kevlar/seqio.py
+++ b/kevlar/seqio.py
@@ -50,6 +50,14 @@ def parse_seq_dict(data):
 
 
 def parse_augmented_fastx(instream):
+    """
+    Read augmented Fast[q|a] records into memory.
+
+    The parsed records will have .name, .sequence, and .quality defined (unless
+    it's augmented Fasta), as well as a list of interesting k-mers. See
+    http://kevlar.readthedocs.io/en/latest/formats.html#augmented-sequences for
+    more information.
+    """
     record = None
     for line in instream:
         if line.startswith(('@', '>')):
@@ -79,6 +87,7 @@ def parse_augmented_fastx(instream):
 
 
 def print_augmented_fastx(record, outstream=stdout):
+    """Write augmented records out to an .augfast[q|a] file."""
     khmer.utils.write_record(record, outstream)
     for kmer in sorted(record.ikmers, key=lambda k: k.offset):
         abundstr = ' '.join([str(a) for a in kmer.abund])

--- a/kevlar/sketch.py
+++ b/kevlar/sketch.py
@@ -31,7 +31,11 @@ class KevlarSketchTypeError(ValueError):
 
 
 def estimate_fpr(sketch):
-    """Stolen shamelessly from khmer/__init__.py"""
+    """
+    Get a rough estimate of the false positive rate of this sketch.
+
+    Stolen shamelessly from khmer/__init__.py
+    """
     sizes = sketch.hashsizes()
     n_ht = float(len(sizes))
     occupancy = float(sketch.n_occupied())


### PR DESCRIPTION
This PR gives descriptive documentation for each kevlar subcommand, which will appear both on the command line with `kevlar <subcommand> -h` and in the CLI docs at ReadTheDocs. I also made a few more docstring additions elsewhere.

Closes #93.