### PR TITLE
Handle contaminants and reference the same way using a unified "mask" interface

### DIFF
--- a/kevlar/cli/filter.py
+++ b/kevlar/cli/filter.py
@@ -70,10 +70,6 @@ def subparser(subparsers):
                              help='minimum abundance required to call a '
                              'k-mer novel; should be the same value used for '
                              '--case_min in `kevlar novel`; default is 5')
-    filter_args.add_argument('--skip2', default=False, action='store_true',
-                             help='skip the second pass over the reads that '
-                             'recalculates abundance after reference and '
-                             'contaminant k-mers are discarded')
     filter_args.add_argument('--ignore', metavar='KM', nargs='+',
                              help='ignore the specified k-mer(s)')
 

--- a/kevlar/cli/filter.py
+++ b/kevlar/cli/filter.py
@@ -23,40 +23,30 @@ def subparser(subparsers):
                                       add_help=False)
     subparser._positionals.title = 'Required inputs'
 
-    refr_args = subparser.add_argument_group(
-        'Reference genome',
-        'A reference genome is not required, but if available can be supplied '
-        'to discard "interesting" k-mers that turn out not to be novel.'
+    mask_args = subparser.add_argument_group(
+        'Reference and contaminant masking',
+        'Two classes of "interesting k-mers" (ikmers) need to be filtered out '
+        'when identifying novel germline mutations: those in the reference '
+        'genome, and those of contaminant origin. When available, provide '
+        'reference genome assemblies and contaminant databases to "mask" out '
+        'these k-mers and remove their "interesting" classification.'
     )
-    refr_args.add_argument('--refr', metavar='FILE', type=str, default=None,
-                           help='reference genome in Fasta/Fastq format')
-    refr_args.add_argument('--refr-memory', metavar='MEM', default='1e6',
+    mask_args.add_argument('--mask', metavar='FA', type=str, default=None,
+                           nargs='+', help='sequences to mask (reference '
+                           'genomes, contaminants); can provide as one or more'
+                           ' Fasta/Fastq files or as a single pre-computed '
+                           'nodetable file; see `--save-mask` option')
+    mask_args.add_argument('--mask-memory', metavar='MEM', default='1e9',
                            type=khmer_args.memory_setting,
-                           help='memory to allocate for storing the reference '
-                           'genome; default is 1M')
-    refr_args.add_argument('--refr-max-fpr', type=float, metavar='FPR',
+                           help='memory to allocate for storing the mask; '
+                           'default is 1G')
+    mask_args.add_argument('--mask-max-fpr', type=float, metavar='FPR',
                            default=0.001, help='terminate if the expected '
                            'false positive rate is higher than the specified '
                            'FPR; default is 0.001')
-
-    contam_args = subparser.add_argument_group(
-        'Screening for known contaminants',
-        'It may not be possible to anticipate every possible contaminant that '
-        'may be present in a sample, but if there is a common or known set of '
-        'contaminants these can be filtered out at this step. Unknown '
-        'contaminants will have to be filtered out after read partitioning.'
-    )
-    contam_args.add_argument('--contam', metavar='FILE', type=str,
-                             default=None, help='database of contaminant '
-                             'sequences in Fasta/Fastq format')
-    contam_args.add_argument('--contam-memory', metavar='MEM', default='1e6',
-                             type=khmer_args.memory_setting,
-                             help='memory to allocate for storing contaminant '
-                             'sequences; default is 1M')
-    contam_args.add_argument('--contam-max-fpr', type=float, metavar='FPR',
-                             default=0.001, help='terminate if the expected '
-                             'false positive rate is higher than the specified'
-                             ' FPR; default is 0.001')
+    mask_args.add_argument('--save-mask', type=str, metavar='FILE',
+                           default=None, help='save mask nodetable to the '
+                           'specified FILE to save time with future runs')
 
     filter_args = subparser.add_argument_group(
         'Filtering k-mers',

--- a/kevlar/collect.py
+++ b/kevlar/collect.py
@@ -111,7 +111,8 @@ def assemble_contigs(countgraph, variants, kmers_to_ignore=None,
             print('[kevlar::collect]     DEBUG kmer:', kmer, file=logfile)
         contigs = asm.assemble(kmer)
         for i, contig in enumerate(contigs):
-            contig = contig.decode()
+            if hasattr(contig, 'decode'):
+                contig = contig.decode()
             if contig == '':
                 print('    WARNING: no linear path found for k-mer', kmer,
                       file=logfile)

--- a/kevlar/filter.py
+++ b/kevlar/filter.py
@@ -86,14 +86,9 @@ def load_input(filelist, ksize, memory, maxfpr=0.001, logfile=sys.stderr):
     return readset, countgraph
 
 
-def validate_and_print(readset, countgraph, mask=None, minabund=5, skip2=False,
+def validate_and_print(readset, countgraph, mask=None, minabund=5,
                        outfile=sys.stdout, augout=None, logfile=sys.stderr):
     readset.validate(countgraph, mask=mask, minabund=minabund)
-    if not skip2:
-        ksize, tablesizes = countgraph.ksize(), countgraph.hashsizes()
-        countgraph = khmer._Countgraph(ksize, tablesizes)
-        readset.recalc_abund(countgraph, minabund)
-
     n = 0  # Get an unbound var error later (printing report) without this?!?!
     for n, record in enumerate(readset):
         khmer.utils.write_record(record, outfile)
@@ -135,7 +130,7 @@ def main(args):
         timer.start('loadmask')
         print('[kevlar::filter] Loading mask from', args.mask,
               file=args.logfile)
-        mask = load_refr(args.mask, args.ksize, args.mask_memory,
+        mask = load_mask(args.mask, args.ksize, args.mask_memory,
                          maxfpr=args.mask_max_fpr, savefile=args.save_mask,
                          logfile=args.logfile)
         elapsed = timer.stop('loadmask')

--- a/kevlar/filter.py
+++ b/kevlar/filter.py
@@ -153,8 +153,8 @@ def main(args):
           file=args.logfile)
     outstream = kevlar.open(args.out, 'w')
     augstream = kevlar.open(args.aug_out, 'w') if args.aug_out else None
-    validate_and_print(readset, countgraph, mask, args.min_abund,
-                       args.skip2, outstream, augstream, args.logfile)
+    validate_and_print(readset, countgraph, mask, args.min_abund, outstream,
+                       augstream, args.logfile)
     elapsed = timer.stop('validate')
     print('[kevlar::filter] k-mers validated and reads printed',
           'in {:.2f} sec'.format(elapsed), file=args.logfile)

--- a/kevlar/filter.py
+++ b/kevlar/filter.py
@@ -16,19 +16,32 @@ from khmer import khmer_args
 import kevlar
 
 
-def load_refr(refrfile, ksize, memory, maxfpr=0.001, logfile=sys.stderr):
+def load_mask(maskfiles, ksize, memory, maxfpr=0.001, savefile=None,
+              logfile=sys.stderr):
     """Load reference genome or contaminant database from a file."""
-    buckets = memory * khmer._buckets_per_byte['nodegraph'] / 4
-    refr = khmer.Nodetable(ksize, buckets, 4)
-    nr, nk = refr.consume_seqfile(refrfile)
-    fpr = kevlar.sketch.estimate_fpr(refr)
-    message = '    {:d} sequences and {:d} k-mers consumed'.format(nr, nk)
+    if len(maskfiles) == 1 and maskfiles[0].endswith(('.nt', '.nodetable')):
+        mask = kevlar.sketch.load(maskfiles[0])
+        message = '    nodetable loaded'
+    else:
+        buckets = memory * khmer._buckets_per_byte['nodegraph'] / 4
+        mask = khmer.Nodetable(ksize, buckets, 4)
+        nr, nk = 0, 0
+        for maskfile in maskfiles:
+            numreads, numkmers = mask.consume_seqfile(maskfile)
+            nr += numreads
+            nk += numkmers
+        message = '    {:d} sequences and {:d} k-mers consumed'.format(nr, nk)
+    fpr = kevlar.sketch.estimate_fpr(mask)
     message += '; estimated false positive rate is {:1.3f}'.format(fpr)
     print(message, file=logfile)
     if fpr > maxfpr:
         print('[kevlar::filter] FPR too high, bailing out', file=logfile)
         sys.exit(1)
-    return refr
+    if savefile:
+        mask.save(savefile)
+        message = '    nodetable saved to "{:s}"'.format(savefile)
+        print(message, file=logfile)
+    return mask
 
 
 def load_input(filelist, ksize, memory, maxfpr=0.001, logfile=sys.stderr):
@@ -73,10 +86,9 @@ def load_input(filelist, ksize, memory, maxfpr=0.001, logfile=sys.stderr):
     return readset, countgraph
 
 
-def validate_and_print(readset, countgraph, refr=None, contam=None, minabund=5,
-                       skip2=False, outfile=sys.stdout, augout=None,
-                       logfile=sys.stderr):
-    readset.validate(countgraph, refr=refr, contam=contam, minabund=minabund)
+def validate_and_print(readset, countgraph, mask=None, minabund=5, skip2=False,
+                       outfile=sys.stdout, augout=None, logfile=sys.stderr):
+    readset.validate(countgraph, mask=mask, minabund=minabund)
     if not skip2:
         ksize, tablesizes = countgraph.ksize(), countgraph.hashsizes()
         countgraph = khmer._Countgraph(ksize, tablesizes)
@@ -110,8 +122,6 @@ def validate_and_print(readset, countgraph, refr=None, contam=None, minabund=5,
     message += '{:d} reads'.format(readset.discarded)
     message += ' with no surviving valid k-mers ignored'
     message += '\n        '
-    message += '{:d} contaminant reads discarded'.format(readset.contam)
-    message += '\n        '
     message += '{:d} reads written to output'.format(n + 1)
     print(message, file=logfile)
 
@@ -120,28 +130,16 @@ def main(args):
     timer = kevlar.Timer()
     timer.start()
 
-    refr = None
-    if args.refr:
-        timer.start('loadrefr')
-        print('[kevlar::filter] Loading reference genome from',
-              args.refr, file=args.logfile)
-        refr = load_refr(args.refr, args.ksize, args.refr_memory,
-                         args.refr_max_fpr, args.logfile)
-        elapsed = timer.stop('loadrefr')
-        print('[kevlar::filter]',
-              'Reference genome loaded in {:.2f} sec'.format(elapsed),
+    mask = None
+    if args.mask:
+        timer.start('loadmask')
+        print('[kevlar::filter] Loading mask from', args.mask,
               file=args.logfile)
-
-    contam = None
-    if args.contam:
-        timer.start('loadcontam')
-        print('[kevlar::filter] Loading contaminants from', args.contam,
-              file=args.logfile)
-        contam = load_refr(args.contam, args.ksize, args.contam_memory,
-                           args.contam_max_fpr, args.logfile)
-        elapsed = timer.stop('loadcontam')
-        print('[kevlar::filter]',
-              'Contaminant database loaded in {:.2f} sec'.format(elapsed),
+        mask = load_refr(args.mask, args.ksize, args.mask_memory,
+                         maxfpr=args.mask_max_fpr, savefile=args.save_mask,
+                         logfile=args.logfile)
+        elapsed = timer.stop('loadmask')
+        print('[kevlar::filter]', 'Mask loaded in {:.2f} sec'.format(elapsed),
               file=args.logfile)
 
     timer.start('recalc')
@@ -160,7 +158,7 @@ def main(args):
           file=args.logfile)
     outstream = kevlar.open(args.out, 'w')
     augstream = kevlar.open(args.aug_out, 'w') if args.aug_out else None
-    validate_and_print(readset, countgraph, refr, contam, args.min_abund,
+    validate_and_print(readset, countgraph, mask, args.min_abund,
                        args.skip2, outstream, augstream, args.logfile)
     elapsed = timer.stop('validate')
     print('[kevlar::filter] k-mers validated and reads printed',

--- a/kevlar/seqio.py
+++ b/kevlar/seqio.py
@@ -154,8 +154,6 @@ class AnnotatedReadSet(object):
             record = self._reads[readid]
             if len(record.ikmers) == 0:
                 continue
-            elif hasattr(record, 'contam') and record.contam is True:
-                continue
             yield record
 
     @property
@@ -199,56 +197,3 @@ class AnnotatedReadSet(object):
             record.ikmers = validated_kmers
             if len(validated_kmers) == 0:
                 self._novalidkmers_count += 1
-
-    def recalc_abund(self, newcounts, minabund=5):
-        for read in self:
-            newcounts.consume(read.sequence)
-        self._valid = defaultdict(int)
-        self._novalidkmers_count = 0
-        self.validate(newcounts, minabund=minabund)
-
-    def group_reads_by_novel_kmers(self, ccprefix, upint=10000,
-                                   logstream=None):
-        n = 0
-        reads_by_novel_kmer = defaultdict(set)
-        novel_kmers = set()  # just for reporting numbers; free memory ASAP
-        for n, read_name in enumerate(self._reads):
-            if logstream and n > 0 and n % upint == 0:
-                print('    store reads by novel k-mers:', n, file=logstream)
-            record = self._reads[read_name]
-            for novel_kmer in record.ikmers:
-                kmer_seq = novel_kmer.sequence
-                kmer_seq_rc = kevlar.revcom(novel_kmer.sequence)
-                reads_by_novel_kmer[kmer_seq].add(record.name)
-                reads_by_novel_kmer[kmer_seq_rc].add(record.name)
-                # Using ternary here instead of kmer.revcommin to avoid
-                # recomputing the reverse complement.
-                min_kmer = kmer_seq if kmer_seq < kmer_seq_rc else kmer_seq_rc
-                novel_kmers.add(min_kmer)
-        num_novel_kmers = len(novel_kmers)
-        del novel_kmers
-
-        read_graph = Graph()
-        for n, read_name in enumerate(self._reads):
-            if logstream and n > 0 and n % upint == 0:
-                print('    build shared novel k-mer graph:', n, file=logstream)
-            record = self._reads[read_name]
-            for kmer in record.ikmers:
-                for other_record_name in reads_by_novel_kmer[kmer.sequence]:
-                    read_graph.add_edge(read_name, other_record_name)
-
-        reads_in_ccs = 0
-        cclog = open(ccprefix + '.cc.log', 'w')
-        for n, cc in enumerate(connected_components(read_graph)):
-            print('CC', n, len(cc), cc, sep='\t', file=cclog)
-            reads_in_ccs += len(cc)
-            outfilename = '{:s}.cc{:d}.augfastq.gz'.format(ccprefix, n)
-            with kevlar.open(outfilename, 'w') as outfile:
-                for readid in cc:
-                    record = self._reads[readid]
-                    kevlar.print_augmented_fastx(record, outfile)
-
-        message = '        grouped {:d} reads'.format(reads_in_ccs)
-        message += ' into {:d} connected components'.format(n + 1)
-        message += ' by {:d} shared novel k-mers'.format(num_novel_kmers)
-        print(message, file=logstream)

--- a/kevlar/seqio.py
+++ b/kevlar/seqio.py
@@ -145,7 +145,6 @@ class AnnotatedReadSet(object):
         self._valid = defaultdict(int)
 
         self._novalidkmers_count = 0
-        self._contam_seqs = 0
 
     def __len__(self):
         return len(self._reads)
@@ -175,10 +174,6 @@ class AnnotatedReadSet(object):
     def discarded(self):
         return self._novalidkmers_count
 
-    @property
-    def contam(self):
-        return self._contam_seqs
-
     def add(self, newrecord):
         if newrecord.name in self._reads:
             record = self._reads[newrecord.name]
@@ -187,20 +182,14 @@ class AnnotatedReadSet(object):
         else:
             self._reads[newrecord.name] = newrecord
 
-    def validate(self, counts, refr=None, contam=None, minabund=5):
+    def validate(self, counts, mask=None, minabund=5):
         for readid in self._reads:
             record = self._reads[readid]
-            if contam:
-                medcount, _, _ = contam.get_median_count(record.sequence)
-                if medcount > 0:
-                    record.contam = True
-                    self._contam_seqs += 1
-                    continue
 
             validated_kmers = list()
             for kmer in record.ikmers:
                 kmerseq = kevlar.revcommin(kmer.sequence)
-                if refr and refr.get(kmerseq) > 0:
+                if mask and mask.get(kmerseq) > 0:
                     self._masked[kmerseq] += 1
                 elif counts.get(kmerseq) < minabund:
                     self._lowabund[kmerseq] += 1

--- a/kevlar/tests/test_filter.py
+++ b/kevlar/tests/test_filter.py
@@ -138,3 +138,24 @@ def test_ctrl3_refr_contam(ctrl3, bogusrefr, bogusrefrcontam):
     kevlar.filter.validate_and_print(readset, countgraph, mask=bogusrefrcontam,
                                      minabund=6)
     assert readset.valid == (13, 171)
+
+
+def test_filter_main(capsys):
+    arglist = [
+        'filter',
+        '--mask',
+        kevlar.tests.data_file('bogus-genome/refr.fa'),
+        kevlar.tests.data_file('bogus-genome/contam1.fa'),
+        '--mask-memory', '10M',
+        '--mask-max-fpr', '0.001',
+        '--abund-memory', '10M',
+        '--abund-max-fpr', '0.001',
+        '--min-abund', '6',
+        '--ksize', '13',
+        kevlar.tests.data_file('trio1/novel_3_1,2.txt'),
+    ]
+    args = kevlar.cli.parser().parse_args(arglist)
+    kevlar.filter.main(args)
+
+    out, err = capsys.readouterr()
+    assert '171 instances of 13 distinct k-mers validated as novel' in err

--- a/kevlar/tests/test_filter.py
+++ b/kevlar/tests/test_filter.py
@@ -120,27 +120,6 @@ def test_validate_with_mask():
             assert kevlar.revcom(ikmer.sequence) != kmer
 
 
-def test_validate_with_mask_2pass():
-    mask = khmer.Nodetable(19, 1e3, 2)
-    mask.consume('CCAGCTGCAGGCCAGGGATCGCCGTGGGCGGACGCCCATACCGCGATAGC')
-    filelist = kevlar.tests.data_glob('collect.gamma.txt')
-
-    # First, without second pass
-    readset, countgraph = kevlar.filter.load_input(filelist, 19, 5e3)
-    kevlar.filter.validate_and_print(readset, countgraph, mask, minabund=8,
-                                     skip2=True)
-    assert readset.valid == (4, 32)
-    assert readset.lowabund == (0, 0)
-    assert readset.discarded == 12
-
-    # Then, with second pass
-    readset, countgraph = kevlar.filter.load_input(filelist, 19, 5e3)
-    kevlar.filter.validate_and_print(readset, countgraph, mask, minabund=8)
-    assert readset.valid == (4, 32)
-    assert readset.lowabund == (0, 0)
-    assert readset.discarded == 12
-
-
 def test_ctrl3(ctrl3):
     readset, countgraph = ctrl3
     kevlar.filter.validate_and_print(readset, countgraph, minabund=6)

--- a/kevlar/tests/test_seqio.py
+++ b/kevlar/tests/test_seqio.py
@@ -107,20 +107,3 @@ def test_kevlar_open(basename):
         'AAGACGGCATACGAGCTCTTTTCACGTGACTGGAGTTCAGACGTGTGCTCTTCCGAT'
     )
     assert len(record.ikmers) == 2
-
-
-def test_group_by_novel_kmers(capsys):
-    import sys
-    readset = kevlar.seqio.AnnotatedReadSet()
-    infilename = kevlar.tests.data_file('topartition.augfastq')
-    tempdir = tempfile.mkdtemp()
-    prefix = '{:s}/cc'.format(tempdir)
-    with kevlar.open(infilename, 'r') as infile:
-        for record in kevlar.parse_augmented_fastx(infile):
-            readset.add(record)
-    readset.group_reads_by_novel_kmers(prefix, logstream=sys.stderr)
-    out, err = capsys.readouterr()
-
-    assert 'grouped 4 reads into 2 connected components' in err
-
-    shutil.rmtree(tempdir)


### PR DESCRIPTION
Our working definition for an "interesting" k-mer is one that is high abundance in the proband and effectively absent from the parents and siblings. In the context of novel germline variant discovery, there are two classes of such "interesting" k-mers we want to ignore.

- Those that are in the reference genome‡.
- Those that are contaminant in origin.

Previously, we've been handling these two cases in different ways. We've done simple k-mer queries against a nodetable containing the reference genome, discarding the k-mer's "interesting" status if there's a hit. However, the contaminant screening has involved looking at the median k-mer abundance of entire "interesting" reads, and discarding the entire read if the median abundance > 0 against the contaminant database. We've tried this latter approach in several different contexts, and it has not performed as well as we would like.

This pull request gets rid of the latter approach, and handles both reference genome queries and contaminant screening using a single aggregate mask.

----------
‡How are these latter even being called "interesting" in the first place? Good question. As far as I can tell, this is the combined effect of sampling/depth artifacts and sequencing errors in the parents. In any case, "interesting" k-mers are *supposed* to be signatures of novelty, and so if they end up being in the reference genome, we discard these.
