### PR TITLE
Refactor kevlar call to support multiple queries, targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Abundance list reported by `kevlar filter` now correctly show re-computed proband k-mer abundances, not pre-filtering abundances as before (see #111).
-- The `kevlar localize` and `kevlar call` procedures now handle multiple assembled contigs and multiple reference matches (see #124).
+- The `kevlar localize` and `kevlar call` procedures now handle multiple assembled contigs and multiple reference matches (see #124 and #126).
 
 ### Added
 - New abundance screen now a part of `kevlar novel`. If any k-mer in a read is below some abundance threshold, the entire read is discarded (see #106).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Abundance list reported by `kevlar filter` now correctly show re-computed proband k-mer abundances, not pre-filtering abundances as before (see #111).
+- The `kevlar localize` and `kevlar call` procedures now handle multiple assembled contigs and multiple reference matches (see #124).
 
 ### Added
 - New abundance screen now a part of `kevlar novel`. If any k-mer in a read is below some abundance threshold, the entire read is discarded (see #106).

--- a/kevlar/call.py
+++ b/kevlar/call.py
@@ -12,25 +12,37 @@ import khmer
 import kevlar
 
 
-class KevlarAmbiguousTargetError(ValueError):
-    pass
+def call(targetlist, querylist, match=1, mismatch=-2, gapopen=5, gapextend=0):
+    """
+    Wrap the `kevlar call` procedure as a generator function.
+
+    Input is the following.
+    - an iterable containing one or more target sequences from the reference
+      genome, stored as khmer or screed sequence records
+    - an iterable containing one or more contigs assembled by kevlar, stored as
+      khmer or screed sequence records
+    - alignment match score (integer)
+    - alignment mismatch penalty (integer)
+    - alignment gap open penalty (integer)
+    - alignment gap extension penalty (integer)
+
+    The function yields tuples of target sequence name, query sequence name,
+    and alignment CIGAR string
+    """
+    for target in sorted(targetlist, key=lambda record: record.name):
+        for query in sorted(querylist, reverse=True, key=len):
+            cigar = kevlar.align(target.sequence, query.sequence, match,
+                                 mismatch, gapopen, gapextend)
+            yield target.name, query.name, cigar
 
 
 def main(args):
     outstream = kevlar.open(args.out, 'w')
-
-    queryseqs = [record for record in khmer.ReadParser(args.queryseq)]
     targetseqs = [record for record in khmer.ReadParser(args.targetseq)]
-    nquerys = len(queryseqs)
-    ntargets = len(targetseqs)
-    if ntargets != 1:
-        message = 'found {:d} target sequences, expected 1'.format(ntargets)
-        raise KevlarAmbiguousTargetError(message)
-
-    queryseqs = sorted(queryseqs, reverse=True, key=len)
-
-    target = targetseqs[0].sequence
-    query = queryseqs[0].sequence
-    cigar = kevlar.align(target, query, args.match, args.mismatch, args.open,
-                         args.extend)
-    print(cigar, file=outstream)
+    queryseqs = [record for record in khmer.ReadParser(args.queryseq)]
+    caller = call(
+        targetseqs, queryseqs,
+        args.match, args.mismatch, args.open, args.extend
+    )
+    for target, query, cigar in caller:
+        print(target, query, cigar, sep='\t', file=outstream)

--- a/kevlar/tests/test_call.py
+++ b/kevlar/tests/test_call.py
@@ -35,4 +35,6 @@ def test_call_cli(targetfile, queryfile, cigar, capsys):
     kevlar.call.main(args)
 
     out, err = capsys.readouterr()
-    assert out.strip() == cigar
+    print(out.split('\n'))
+    cigars = [line.split()[-1] for line in out.strip().split('\n')]
+    assert cigar in cigars


### PR DESCRIPTION
This pull request introduces two changes to the `kevlar call` procedure. First, multiple queries (contigs assembled by kevlar) and multiple target matches (reference sequences to which variants map) are explicitly supported. Second, the code was reorganized to facilitate composition of the `kevlar call` procedure with other operations at the Python API level (see #95).