### PR TITLE
Handle hits to multiple distant loci

### DIFF
--- a/kevlar/cli/localize.py
+++ b/kevlar/cli/localize.py
@@ -23,7 +23,7 @@ def subparser(subparsers):
                            default=1000, help='span of all k-mer starting '
                            'positions should not exceed X bp')
     subparser.add_argument('-d', '--delta', type=int, metavar='D',
-                           default=100, help='retrieve the genomic interval '
+                           default=25, help='retrieve the genomic interval '
                            'from the reference by extending beyond the span '
                            'of all k-mer starting positions by D bp')
     subparser.add_argument('-o', '--out', metavar='FILE', default='-',

--- a/kevlar/tests/test_localize.py
+++ b/kevlar/tests/test_localize.py
@@ -25,11 +25,18 @@ from kevlar.tests import data_file
 
 def test_interval_set_simple():
     intervals = IntervalSet()
-    assert intervals.get('chr1') == (None, None)
+    assert intervals.get_spans('chr1') is None
 
-    intervals.add('chr1', 100, 25)
-    intervals.add('chr1', 115, 25)
-    assert intervals.get('chr1') == (100, 140)
+    intervals.add('chr1', 100, 125)
+    intervals.add('chr1', 115, 140)
+    assert intervals.get_spans('chr1') == [(100, 140)]
+
+    intervals.add('chr2', 200, 225)
+    intervals.add('chr2', 205, 230)
+    intervals.add('chr2', 207, 232)
+    intervals.add('chr2', 235008, 235033)
+    intervals.add('chr2', 235075, 235100)
+    assert intervals.get_spans('chr2') == [(200, 232), (235008, 235100)]
 
 
 @pytest.mark.parametrize('infile', [
@@ -65,20 +72,20 @@ def test_unique_kmer_string():
     assert kmers == testkmers
 
 
-def test_extract_region_basic():
+def test_extract_regions_basic():
     intervals = IntervalSet()
-    intervals.add('bogus-genome-chr2', 10, 10)
+    intervals.add('bogus-genome-chr2', 10, 20)
     instream = open(data_file('bogus-genome/refr.fa'), 'r')
     regions = [r for r in extract_regions(instream, intervals, delta=0)]
     assert len(regions) == 1
     assert regions[0] == ('bogus-genome-chr2_10-20', 'GTTACATTAC')
 
 
-def test_extract_region_basic_2():
+def test_extract_regions_basic_2():
     intervals = IntervalSet()
-    intervals.add('simple', 49, 21)
-    intervals.add('simple', 52, 21)
-    intervals.add('simple', 59, 21)
+    intervals.add('simple', 49, 49 + 21)
+    intervals.add('simple', 52, 52 + 21)
+    intervals.add('simple', 59, 59 + 21)
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
     regions = [r for r in extract_regions(instream, intervals, delta=5)]
     assert len(regions) == 1
@@ -86,46 +93,45 @@ def test_extract_region_basic_2():
                           'AATACTATGCCGATTTATTCTTACACAATTAAATTGCTAGT')
 
 
-def test_extract_region_large_span():
+def test_extract_regions_large_span():
     intervals = IntervalSet()
-    intervals.add('simple', 100, 21)
-    intervals.add('simple', 200, 21)
+    intervals.add('simple', 100, 121)
+    intervals.add('simple', 200, 221)
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
-    with pytest.raises(KevlarVariantLocalizationError) as vle:
-        _ = [r for r in extract_regions(instream, intervals, maxspan=100)]
-    assert 'variant spans 221 bp (max 100)' in str(vle)
+    seqids = [r[0] for r in extract_regions(instream, intervals, maxdiff=50)]
+    assert seqids == ['simple_75-146', 'simple_175-246']
 
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
-    regions = [r for r in extract_regions(instream, intervals)]
+    regions = [r for r in extract_regions(instream, intervals, delta=50)]
     assert len(regions) == 1
     assert regions[0][0] == 'simple_50-271'
 
 
-def test_extract_region_missing_seq():
+def test_extract_regions_missing_seq():
     intervals = IntervalSet()
-    intervals.add('simple', 100, 21)
-    intervals.add('simple', 200, 21)
-    intervals.add('TheCakeIsALie', 42, 21)
-    intervals.add('TheCakeIsALie', 100, 21)
-    intervals.add('TheCakeIsALie', 77, 21)
+    intervals.add('simple', 100, 121)
+    intervals.add('simple', 200, 221)
+    intervals.add('TheCakeIsALie', 42, 63)
+    intervals.add('TheCakeIsALie', 100, 121)
+    intervals.add('TheCakeIsALie', 77, 98)
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
     with pytest.raises(KevlarRefrSeqNotFoundError) as rnf:
         _ = [r for r in extract_regions(instream, intervals)]
     assert 'TheCakeIsALie' in str(rnf)
 
 
-def test_extract_region_boundaries():
+def test_extract_regions_boundaries():
     intervals = IntervalSet()
-    intervals.add('simple', 15, 31)
+    intervals.add('simple', 15, 46)
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
     regions = [r for r in extract_regions(instream, intervals, delta=20)]
     assert len(regions) == 1
     assert regions[0][0] == 'simple_0-66'
 
     intervals = IntervalSet()
-    intervals.add('simple', 925, 31)
-    intervals.add('simple', 955, 31)
-    intervals.add('simple', 978, 31)
+    intervals.add('simple', 925, 925 + 31)
+    intervals.add('simple', 955, 955 + 31)
+    intervals.add('simple', 978, 978 + 31)
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
     regions = [r for r in extract_regions(instream, intervals, delta=20)]
     assert len(regions) == 1
@@ -135,7 +141,7 @@ def test_extract_region_boundaries():
 def test_main(capsys):
     contig = data_file('localize-contig.fa')
     refr = data_file('localize-refr.fa')
-    arglist = ['localize', '--ksize', '23', contig, refr]
+    arglist = ['localize', '--ksize', '23', '--delta', '50', contig, refr]
     args = kevlar.cli.parser().parse_args(arglist)
     kevlar.localize.main(args)
     out, err = capsys.readouterr()

--- a/kevlar/tests/test_localize.py
+++ b/kevlar/tests/test_localize.py
@@ -14,7 +14,7 @@ except ImportError:
 import pytest
 import screed
 import kevlar
-from kevlar.localize import IntervalSet
+from kevlar.localize import KmerMatchSet
 from kevlar.localize import (KevlarRefrSeqNotFoundError,
                              KevlarVariantLocalizationError,
                              KevlarNoReferenceMatchesError)
@@ -24,18 +24,18 @@ from kevlar.tests import data_file
 
 
 def test_interval_set_simple():
-    intervals = IntervalSet()
+    intervals = KmerMatchSet(ksize=25)
     assert intervals.get_spans('chr1') is None
 
-    intervals.add('chr1', 100, 125)
-    intervals.add('chr1', 115, 140)
+    intervals.add('chr1', 100)
+    intervals.add('chr1', 115)
     assert intervals.get_spans('chr1') == [(100, 140)]
 
-    intervals.add('chr2', 200, 225)
-    intervals.add('chr2', 205, 230)
-    intervals.add('chr2', 207, 232)
-    intervals.add('chr2', 235008, 235033)
-    intervals.add('chr2', 235075, 235100)
+    intervals.add('chr2', 200)
+    intervals.add('chr2', 205)
+    intervals.add('chr2', 207)
+    intervals.add('chr2', 235008)
+    intervals.add('chr2', 235075)
     assert intervals.get_spans('chr2') == [(200, 232), (235008, 235100)]
 
 
@@ -73,8 +73,8 @@ def test_unique_kmer_string():
 
 
 def test_extract_regions_basic():
-    intervals = IntervalSet()
-    intervals.add('bogus-genome-chr2', 10, 20)
+    intervals = KmerMatchSet(ksize=10)
+    intervals.add('bogus-genome-chr2', 10)
     instream = open(data_file('bogus-genome/refr.fa'), 'r')
     regions = [r for r in extract_regions(instream, intervals, delta=0)]
     assert len(regions) == 1
@@ -82,10 +82,10 @@ def test_extract_regions_basic():
 
 
 def test_extract_regions_basic_2():
-    intervals = IntervalSet()
-    intervals.add('simple', 49, 49 + 21)
-    intervals.add('simple', 52, 52 + 21)
-    intervals.add('simple', 59, 59 + 21)
+    intervals = KmerMatchSet(ksize=21)
+    intervals.add('simple', 49)
+    intervals.add('simple', 52)
+    intervals.add('simple', 59)
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
     regions = [r for r in extract_regions(instream, intervals, delta=5)]
     assert len(regions) == 1
@@ -94,9 +94,9 @@ def test_extract_regions_basic_2():
 
 
 def test_extract_regions_large_span():
-    intervals = IntervalSet()
-    intervals.add('simple', 100, 121)
-    intervals.add('simple', 200, 221)
+    intervals = KmerMatchSet(ksize=21)
+    intervals.add('simple', 100)
+    intervals.add('simple', 200)
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
     seqids = [r[0] for r in extract_regions(instream, intervals, maxdiff=50)]
     assert seqids == ['simple_75-146', 'simple_175-246']
@@ -108,12 +108,12 @@ def test_extract_regions_large_span():
 
 
 def test_extract_regions_missing_seq():
-    intervals = IntervalSet()
-    intervals.add('simple', 100, 121)
-    intervals.add('simple', 200, 221)
-    intervals.add('TheCakeIsALie', 42, 63)
-    intervals.add('TheCakeIsALie', 100, 121)
-    intervals.add('TheCakeIsALie', 77, 98)
+    intervals = KmerMatchSet(ksize=21)
+    intervals.add('simple', 100)
+    intervals.add('simple', 200)
+    intervals.add('TheCakeIsALie', 42)
+    intervals.add('TheCakeIsALie', 100)
+    intervals.add('TheCakeIsALie', 77)
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
     with pytest.raises(KevlarRefrSeqNotFoundError) as rnf:
         _ = [r for r in extract_regions(instream, intervals)]
@@ -121,17 +121,17 @@ def test_extract_regions_missing_seq():
 
 
 def test_extract_regions_boundaries():
-    intervals = IntervalSet()
-    intervals.add('simple', 15, 46)
+    intervals = KmerMatchSet(ksize=31)
+    intervals.add('simple', 15)
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
     regions = [r for r in extract_regions(instream, intervals, delta=20)]
     assert len(regions) == 1
     assert regions[0][0] == 'simple_0-66'
 
-    intervals = IntervalSet()
-    intervals.add('simple', 925, 925 + 31)
-    intervals.add('simple', 955, 955 + 31)
-    intervals.add('simple', 978, 978 + 31)
+    intervals = KmerMatchSet(ksize=31)
+    intervals.add('simple', 925)
+    intervals.add('simple', 955)
+    intervals.add('simple', 978)
     instream = open(data_file('simple-genome-ctrl1.fa'), 'r')
     regions = [r for r in extract_regions(instream, intervals, delta=20)]
     assert len(regions) == 1


### PR DESCRIPTION
As of #126, `kevlar localize` can handle contigs that align to multiple chromosomes. This PR now handles cases in which a contig aligns to multiple distant loci on the same chromosome.

The implementation is a bit messy. Tests are passing, but they are simple. I need a few more before I'll be comfortable on unleashing this on real data.