### PR TITLE
New "--skip-until" option

### DIFF
--- a/kevlar/cli/novel.py
+++ b/kevlar/cli/novel.py
@@ -141,7 +141,7 @@ def subparser(subparsers):
     misc_args.add_argument('-t', '--threads', type=int, default=1, metavar='T',
                            help='number of threads to use for file processing;'
                            ' default is 1')
-    misc_args.add_argument('--skip-until', type=str, metavar='READID',
+    misc_args.add_argument('--skip-until', type=str, metavar='ID',
                            help='when re-running `kevlar novel`, skip all '
-                           'reads in the case input until read READID is '
-                           'observed')
+                           'reads in the case input until read with name `ID` '
+                           'is observed')

--- a/kevlar/cli/novel.py
+++ b/kevlar/cli/novel.py
@@ -141,3 +141,7 @@ def subparser(subparsers):
     misc_args.add_argument('-t', '--threads', type=int, default=1, metavar='T',
                            help='number of threads to use for file processing;'
                            ' default is 1')
+    misc_args.add_argument('--skip-until', type=str, metavar='READID',
+                           help='when re-running `kevlar novel`, skip all '
+                           'reads in the case input until read READID is '
+                           'observed')

--- a/kevlar/novel.py
+++ b/kevlar/novel.py
@@ -122,6 +122,13 @@ def main(args):
     outstream = kevlar.open(args.out, 'w')
     infiles = [f for filelist in args.case for f in filelist]
     for n, record in enumerate(kevlar.multi_file_iter_screed(infiles), 1):
+        if args.skip_until:
+            if record.name == args.skip_until:
+                message = 'Found read {:s}'.format(args.skip_until)
+                message += ' (skipped {:d} reads)'.format(n)
+                print('[kevlar::novel]', message, file=args.logfile)
+                args.skip_until = False
+            continue
         if n > 0 and n % args.upint == 0:
             elapsed = timer.probe('iter')
             msg = '    processed {} reads'.format(n)

--- a/kevlar/tests/test_novel.py
+++ b/kevlar/tests/test_novel.py
@@ -166,8 +166,8 @@ def test_skip_until(capsys):
     case = kevlar.tests.data_file('trio1/case1.fq')
     ctrls = kevlar.tests.data_glob('trio1/ctrl[1,2].fq')
     arglist = ['novel', '--ctrl-max', '0', '--case-min', '6',
-               '--skip-until', readname, '--case', case,
-               '--control', ctrls[0], '--control', ctrls[1]]
+               '--skip-until', readname, '--upint', '50',
+               '--case', case, '--control', ctrls[0], '--control', ctrls[1]]
     args = kevlar.cli.parser().parse_args(arglist)
     kevlar.novel.main(args)
 

--- a/kevlar/tests/test_novel.py
+++ b/kevlar/tests/test_novel.py
@@ -159,3 +159,20 @@ def test_novel_abund_screen(capsys):
 
     out, err = capsys.readouterr()
     assert '>seq_error' not in out
+
+
+def test_skip_until(capsys):
+    readname = 'bogus-genome-chr1_115_449_0:0:0_0:0:0_1f4/1'
+    case = kevlar.tests.data_file('trio1/case1.fq')
+    ctrls = kevlar.tests.data_glob('trio1/ctrl[1,2].fq')
+    arglist = ['novel', '--ctrl-max', '0', '--case-min', '6',
+               '--skip-until', readname, '--case', case,
+               '--control', ctrls[0], '--control', ctrls[1]]
+    args = kevlar.cli.parser().parse_args(arglist)
+    kevlar.novel.main(args)
+
+    out, err = capsys.readouterr()
+    message = ('Found read bogus-genome-chr1_115_449_0:0:0_0:0:0_1f4/1 '
+               '(skipped 1001 reads)')
+    assert message in err
+    assert '29 unique novel kmers in 14 reads' in err


### PR DESCRIPTION
This PR introduces a new `--skip-until` flag for `kevlar novel`. All input reads are ignored until the read with the specified ID is encountered. Fault tolerance FTW. Closes #131.