### PR TITLE
Call trim-low-abund from kevlar partition

### DIFF
--- a/kevlar/cli/partition.py
+++ b/kevlar/cli/partition.py
@@ -35,5 +35,9 @@ def subparser(subparsers):
                            default=True, help='skip step to remove duplicates')
     subparser.add_argument('--gml', metavar='FILE',
                            help='write read graph to .gml file')
+    subparser.add_argument('--trim', type=int, default=18, metavar='N',
+                           help='perform abundance trimming on partitions '
+                           'containing N or more reads; default is 18; set to '
+                           '-1 to disable')
     subparser.add_argument('outprefix', help='prefix for output files')
     subparser.add_argument('augfastq', help='original augmented Fastq file')

--- a/kevlar/tests/test_partition.py
+++ b/kevlar/tests/test_partition.py
@@ -62,7 +62,7 @@ def test_partition_nodedup(capsys):
     args = kevlar.cli.parser().parse_args(arglist)
     kevlar.partition.main(args)
     out, err = capsys.readouterr()
-    assert 'grouped 18 reads into 1 connected components' in err
+    assert 'grouped 17 reads into 1 connected components' in err
 
     outfile = tempdir + '/nodedup.cc1.augfastq.gz'
     stream = kevlar.open(outfile, 'r')
@@ -72,7 +72,6 @@ def test_partition_nodedup(capsys):
         'AACGAACCACCTCAATGATGACCTTTATGCTTCCACGGCAAATGGTGCGG',
         'ACGAACCACCTCAATGATGACCTTTATGCTTCCACGGCAAATGGTGCGGT',
         'AGGGCACACCTAACCGCACCATTTGCCGTGGAAGCATAAAGGTCATCATT',
-        'ATCGGAACGAACCACCTCAATGATGACCTTTATGCTTCCACGGCAAATGG',
         'CACACCTAACCGCACCATTTGCCGTGGAAGCATAAAGGTCATCATTGAGG',
         'CCACCTCAATGATGACCTTTATGCTTCCACGGCAAATGGTGCGGTTAGGT',
         'CCTCAATGATGACCTTTATGCTTCCACGGCAAATGGTGCGGTTAGGTGTG',


### PR DESCRIPTION
In combination with the recent `kevlar reaugment` bugfix, I'm hoping this improves some assemblies. In any case, it should make it easier to compose the entire workflow.