### PR TITLE
Make refr setting optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- The `--refr` argument of the `kevlar dump` command is now optional, and when no reference is explicitly specified `kevlar dump` acts primarily as a BAM to Fastq converter.
+
 ### Fixed
 - Incorrect file names in the quick start documentation page.
-- The `kevlar alac` procedure now accepts a stream of read partitions (instead of a stream of reads) at the Python API level, and correctly handles a single partition labeled sequence file at the CLI leve.
+- The `kevlar alac` procedure now accepts a stream of read partitions (instead of a stream of reads) at the Python API level, and correctly handles a single partition labeled sequence file at the CLI level.
 
 ## [0.3.0] - 2017-11-03
 

--- a/kevlar/cli/dump.py
+++ b/kevlar/cli/dump.py
@@ -17,7 +17,8 @@ def subparser(subparsers):
     desc = 'Discard reads that align perfectly to the reference genome.'
 
     subparser = subparsers.add_parser('dump', description=desc)
-    subparser.add_argument('--out', metavar='FILE', help='output file; default'
-                           ' is terminal (stdout)')
-    subparser.add_argument('refr', help='reference sequence in Fasta format')
+    subparser.add_argument('-o', '--out', metavar='FILE', help='output file; '
+                           'default is terminal (stdout)')
+    subparser.add_argument('-r', '--refr', metavar='REFR', help='reference '
+                           'sequence in Fasta format')
     subparser.add_argument('reads', help='read alignments in BAM format')

--- a/kevlar/dump.py
+++ b/kevlar/dump.py
@@ -15,6 +15,13 @@ from khmer.utils import write_record
 
 
 def perfectmatch(record, bam, refrseqs):
+    """
+    Determine if the alignment record is a perfect match against the reference.
+
+    The `record` is a pysam alignment object, `bam` is a pysam BAM parser
+    object, and `refrseqs` is a dictionary of sequences indexed by their
+    sequence IDs.
+    """
     matchcigar = '{:d}M'.format(record.rlen)
     if record.cigarstring == matchcigar:
         seq = refrseqs[bam.get_reference_name(record.tid)]
@@ -25,6 +32,7 @@ def perfectmatch(record, bam, refrseqs):
 
 
 def readname(record):
+    """Create a Fastq read name, using suffixes for paired reads as needed."""
     name = record.qname
     if record.flag & 1:
         # Logical XOR: if the read is paired, it should be first in pair
@@ -37,9 +45,17 @@ def readname(record):
 
 
 def dump(bamstream, refrseqs=None, upint=50000, logstream=sys.stderr):
+    """
+    Parse read alignments in BAM/SAM format.
+
+    - bamstream: open file handle to the BAM/SAM file input
+    - refrseqs: dictionary of reference sequences, indexed by sequence ID
+    - upint: update interval for progress indicator
+    - logstream: file handle do which progress indicator will write output
+    """
     bam = pysam.AlignmentFile(bamstream, 'rb')
     for i, record in enumerate(bam, 1):
-        if i % upint == 0:
+        if i % upint == 0:  # pragma: no cover
             print('...processed', i, 'records', file=logstream)
         if record.is_secondary or record.is_supplementary:
             continue

--- a/kevlar/dump.py
+++ b/kevlar/dump.py
@@ -49,7 +49,8 @@ def dump(bamstream, refrseqs=None, upint=50000, logstream=sys.stderr):
     Parse read alignments in BAM/SAM format.
 
     - bamstream: open file handle to the BAM/SAM file input
-    - refrseqs: dictionary of reference sequences, indexed by sequence ID
+    - refrseqs: dictionary of reference sequences, indexed by sequence ID; if
+      provided, perfect matches to the reference sequence will be discarded
     - upint: update interval for progress indicator
     - logstream: file handle do which progress indicator will write output
     """

--- a/kevlar/dump.py
+++ b/kevlar/dump.py
@@ -36,7 +36,7 @@ def readname(record):
     return name
 
 
-def dump(bamstream, refrseqs, upint=50000, logstream=sys.stderr):
+def dump(bamstream, refrseqs=None, upint=50000, logstream=sys.stderr):
     bam = pysam.AlignmentFile(bamstream, 'rb')
     for i, record in enumerate(bam, 1):
         if i % upint == 0:

--- a/kevlar/tests/test_dump.py
+++ b/kevlar/tests/test_dump.py
@@ -16,7 +16,7 @@ from kevlar.tests import data_file
 def test_basic(capsys):
     arglist = [
         'dump',
-        data_file('bogus-genome/refr.fa'),
+        '--refr', data_file('bogus-genome/refr.fa'),
         data_file('bogus-genome/reads.bam'),
     ]
     args = kevlar.cli.parser().parse_args(arglist)
@@ -35,7 +35,7 @@ def test_basic(capsys):
 def test_indels(capsys):
     arglist = [
         'dump',
-        data_file('bogus-genome/refr.fa'),
+        '-r', data_file('bogus-genome/refr.fa'),
         data_file('bogus-genome/reads-indels.bam'),
     ]
     args = kevlar.cli.parser().parse_args(arglist)
@@ -46,16 +46,11 @@ def test_indels(capsys):
     assert len(outputlines) == 4 * 4  # 4 records, 4 lines per record
 
 
-def test_suffix(capsys):
-    arglist = [
-        'dump',
-        data_file('bogus-genome/refr.fa'),
-        data_file('nopair.sam'),
-    ]
-    args = kevlar.cli.parser().parse_args(arglist)
-    kevlar.dump.main(args)
-    out, err = capsys.readouterr()
+def test_suffix():
+    bamstream = kevlar.open(data_file('nopair.sam'), 'r')
+    refrstream = kevlar.open(data_file('bogus-genome/refr.fa'), 'r')
+    refr = kevlar.seqio.parse_seq_dict(refrstream)
 
-    outputlines = out.strip().split('\n')
-    assert len(outputlines) == 4
-    assert outputlines[0].endswith('/1') or outputlines[0].endswith('/2')
+    records = [r for r in kevlar.dump.dump(bamstream, refr)]
+    assert len(records) == 1
+    assert records[0].name.endswith('/1') or records[0].name.endswith('/2')

--- a/kevlar/tests/test_dump.py
+++ b/kevlar/tests/test_dump.py
@@ -32,6 +32,12 @@ def test_basic(capsys):
     assert 'read8' in outputlines[16]
 
 
+def test_no_refr():
+    bamstream = kevlar.open(data_file('bogus-genome/reads.bam'), 'r')
+    records = [r for r in kevlar.dump.dump(bamstream)]
+    assert len(records) == 8
+
+
 def test_indels(capsys):
     arglist = [
         'dump',


### PR DESCRIPTION
The `kevlar dump` command was originally designed to discard any reads that match the reference genome perfectly. This will not be appropriate in some (all?) use cases, but the command still has utility as a BAM to Fastq converter. This PR makes the `--refr` setting optional for `kevlar dump`.