### PR TITLE
Speed up mutation simulations with mutable string implementation

### DIFF
--- a/kevlar/__init__.py
+++ b/kevlar/__init__.py
@@ -25,6 +25,7 @@ from kevlar import seqio
 from kevlar import overlap
 from kevlar import counting
 from kevlar import sketch
+from kevlar.mutablestring import MutableString
 from kevlar.readgraph import ReadGraph
 from kevlar.seqio import parse_augmented_fastx, print_augmented_fastx
 from kevlar.seqio import parse_partitioned_reads

--- a/kevlar/gentrio.py
+++ b/kevlar/gentrio.py
@@ -202,7 +202,7 @@ def gentrio(sequences, outstreams, ninh=20, ndenovo=10, seed=None, upint=100,
         for ind in range(3):  # proband mother father
             haploseqs = [MutableString(sequence), MutableString(sequence)]
             for n, variant in enumerate(variants, 1):
-                if n % upint == 0:
+                if n % upint == 0:  # pragma: no cover
                     message = (
                         '    sequence={seq} individual={ind} '
                         'variantsprocessed={vp}'.format(

--- a/kevlar/mutablestring.py
+++ b/kevlar/mutablestring.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2017 The Regents of the University of California
+#
+# This file is part of kevlar (http://github.com/dib-lab/kevlar) and is
+# licensed under the MIT license: see LICENSE.
+# -----------------------------------------------------------------------------
+
+class MutableString(object):
+    """
+    Mutable string class
+
+    Borrows heavily from https://stackoverflow.com/a/10572792/459780.
+    """
+
+    def __init__(self, data):
+        self.data = list(data)
+
+    def __str__(self):
+        return ''.join(self.data)
+
+    def __repr__(self):
+        return str(self)
+
+    def __eq__(self, other):
+        return str(self) == str(other)
+
+    def __add__(self, chars):
+        """
+        Addition operator
+
+        For consistency with other Python objects, the addition operator
+        creates a new object rather than appending in place. However, this
+        makes a copy of the data which goes against the performance this data
+        structure optimizes for.
+        """
+        newdata = list(self.data) + list(str(chars))
+        return MutableString(''.join(newdata))
+
+    def __iadd__(self, chars):
+        self.data.extend(list(str(chars)))
+        return self
+
+    def __contains__(self, teststr):
+        return teststr in str(self)
+
+    def __setitem__(self, index, value):
+        self.data[index] = value
+
+    def __getitem__(self, index):
+        if type(index) == slice:
+            return ''.join(self.data[index])
+        return self.data[index]
+
+    def __delitem__(self, index):
+        del self.data[index]
+
+    def __len__(self):
+        return len(self.data)

--- a/kevlar/tests/test_gentrio.py
+++ b/kevlar/tests/test_gentrio.py
@@ -15,6 +15,7 @@ from tempfile import mkdtemp
 from shutil import rmtree
 import sys
 import kevlar
+from kevlar import MutableString
 from kevlar.tests import data_file
 
 
@@ -166,21 +167,32 @@ def test_sim_var_geno():
 
 
 def test_apply_mut_snv():
-    contig = 'ACGTACGTACGT'
-    assert kevlar.gentrio.apply_mutation(contig, 5, 'C', 'G') == 'ACGTAGGTACGT'
-    assert kevlar.gentrio.apply_mutation(contig, 5, 'C', 'A') == 'ACGTAAGTACGT'
-    assert kevlar.gentrio.apply_mutation(contig, 0, 'A', 'T') == 'TCGTACGTACGT'
+    contig = MutableString('ACGTACGTACGT')
+
+    kevlar.gentrio.apply_mutation(contig, 5, 'C', 'G')
+    assert contig == 'ACGTAGGTACGT'
+
+    kevlar.gentrio.apply_mutation(contig, 5, 'G', 'A')
+    assert contig == 'ACGTAAGTACGT'
+
+    kevlar.gentrio.apply_mutation(contig, 0, 'A', 'T')
+    assert contig == 'TCGTAAGTACGT'
 
 
 def test_apply_mut_ins():
-    contig = 'ACGTACGTACGT'
-    mutcontig = kevlar.gentrio.apply_mutation(contig, 5, 'C', 'CAAAA')
-    assert mutcontig == 'ACGTAAAAAGTACGT'
+    contig = MutableString('ACGTACGTACGT')
+    kevlar.gentrio.apply_mutation(contig, 5, 'A', 'AAAAA')
+    assert contig == 'ACGTAAAAACGTACGT'
+
+    contig = MutableString('CTTGAGACTTAGTAAAACCGTC')
+    kevlar.gentrio.apply_mutation(contig, 7, 'A', 'ATTCTTGTT')
+    assert contig == 'CTTGAGATTCTTGTTCTTAGTAAAACCGTC'
 
 
 def test_apply_mut_del():
-    contig = 'ACGTACGTACGT'
-    assert kevlar.gentrio.apply_mutation(contig, 5, 'ACGTAC', 'A') == 'ACGTAGT'
+    contig = MutableString('ACGTACGTACGT')
+    kevlar.gentrio.apply_mutation(contig, 5, 'ACGTAC', 'A')
+    assert contig == 'ACGTAGT'
 
 
 def test_gentrio_smoketest():

--- a/kevlar/tests/test_mutablestring.py
+++ b/kevlar/tests/test_mutablestring.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2017 The Regents of the University of California
+#
+# This file is part of kevlar (http://github.com/dib-lab/kevlar) and is
+# licensed under the MIT license: see LICENSE.
+# -----------------------------------------------------------------------------
+
+import pytest
+import kevlar
+from kevlar import MutableString
+
+
+@pytest.mark.parametrize('thestring', [
+    ('GATTACA'),
+    ('ATGNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNTGA'),
+    ('MAHERSHALALHASHBAZ')
+])
+def test_basic(thestring):
+    ms = MutableString(thestring)
+    assert str(ms) == thestring
+    assert repr(ms) == thestring
+    assert ms == thestring
+    assert len(ms) == len(thestring)
+    assert ms[3] == thestring[3]
+    assert ms[2:6] == thestring[2:6]
+
+
+def test_add_ops():
+    ms = MutableString('HOWGOESIT')
+    assert ms + 'MAN' == 'HOWGOESITMAN'
+    assert ms + MutableString('MAN') == 'HOWGOESITMAN'
+
+    ms += 'MANS!'
+    assert ms == 'HOWGOESITMANS!'
+    assert 'ITMANS' in ms
+
+    ms[9:9] = "FELLOWHU"
+    assert ms == 'HOWGOESITFELLOWHUMANS!'
+
+
+def test_del_ops():
+    ms = MutableString('Sesame seed buns')
+    del ms[15]
+    assert ms == 'Sesame seed bun'
+
+    del ms[7:12]
+    assert ms == 'Sesame bun'


### PR DESCRIPTION
The code to simulate mutations (SNVs and INDELs) is heavy on the string manipulation. When applying this code to large sequences, the immutability of Python's builtin strings results in a lot of unnecessary copying.

This PR introduces a new `MutableString` class, which speeds up these simulations by about an order of magnitude.