### PR TITLE
Mutate duplicated sequences

### DIFF
--- a/kevlar/gentrio.py
+++ b/kevlar/gentrio.py
@@ -82,6 +82,7 @@ def mutate_snv(sequence, position, offset, ksize=31):
 
 def mutate_insertion(sequence, position, length, duplpos, rng=None, ksize=31):
     duplseq = mutagenize(sequence[duplpos:duplpos + length], rng, rate=0.05)
+    print('DEBUG', duplseq, file=sys.stderr)
     refrseq = sequence[position - 1]
     altseq = refrseq + duplseq
 
@@ -142,14 +143,12 @@ def generate_mutations(sequences, n=10, inversions=False, ksize=31, rng=None):
             refrseq, altseq, refrwindow, altwindow = mutate_insertion(
                 seq, position, length, duplpos, rng, ksize
             )
-            position -= 1
         else:
             assert muttype == 'del'
             length = rng.randint(5, 350)
             refrseq, altseq, refrwindow, altwindow = mutate_deletion(
                 seq, position, length, ksize
             )
-            position -= 1
         yield Variant(seqid, position, refrseq, altseq, VW=altwindow,
                       RW=refrwindow)
 

--- a/kevlar/gentrio.py
+++ b/kevlar/gentrio.py
@@ -142,12 +142,14 @@ def generate_mutations(sequences, n=10, inversions=False, ksize=31, rng=None):
             refrseq, altseq, refrwindow, altwindow = mutate_insertion(
                 seq, position, length, duplpos, rng, ksize
             )
+            position -= 1
         else:
             assert muttype == 'del'
             length = rng.randint(5, 350)
             refrseq, altseq, refrwindow, altwindow = mutate_deletion(
                 seq, position, length, ksize
             )
+            position -= 1
         yield Variant(seqid, position, refrseq, altseq, VW=altwindow,
                       RW=refrwindow)
 

--- a/kevlar/gentrio.py
+++ b/kevlar/gentrio.py
@@ -52,6 +52,17 @@ def weighted_choice(values, weights, rng=random.Random()):
     assert False  # pragma: no cover
 
 
+def mutagenize(sequence, rng=None, rate=0.05):
+    mutseq = list()
+    for nucl in sequence:
+        if rng and rng.random() < rate:
+            offset = rng.choice([1, 2, 3])
+            newindex = (nucl_to_index[nucl] + offset) % 4
+            nucl = index_to_nucl[newindex]
+        mutseq.append(nucl)
+    return ''.join(mutseq)
+
+
 def mutate_snv(sequence, position, offset, ksize=31):
     orignucl = sequence[position]
     nuclindex = nucl_to_index[orignucl]
@@ -69,8 +80,8 @@ def mutate_snv(sequence, position, offset, ksize=31):
     return orignucl, newnucl, refrwindow, altwindow
 
 
-def mutate_insertion(sequence, position, length, duplpos, ksize=31):
-    duplseq = sequence[duplpos:duplpos + length]
+def mutate_insertion(sequence, position, length, duplpos, rng=None, ksize=31):
+    duplseq = mutagenize(sequence[duplpos:duplpos + length], rng, rate=0.05)
     refrseq = sequence[position - 1]
     altseq = refrseq + duplseq
 
@@ -129,7 +140,7 @@ def generate_mutations(sequences, n=10, inversions=False, ksize=31, rng=None):
             length = rng.randint(5, 350)
             duplpos = rng.randint(0, seqlength)
             refrseq, altseq, refrwindow, altwindow = mutate_insertion(
-                seq, position, length, duplpos, ksize
+                seq, position, length, duplpos, rng, ksize
             )
         else:
             assert muttype == 'del'

--- a/kevlar/gentrio.py
+++ b/kevlar/gentrio.py
@@ -82,7 +82,6 @@ def mutate_snv(sequence, position, offset, ksize=31):
 
 def mutate_insertion(sequence, position, length, duplpos, rng=None, ksize=31):
     duplseq = mutagenize(sequence[duplpos:duplpos + length], rng, rate=0.05)
-    print('DEBUG', duplseq, file=sys.stderr)
     refrseq = sequence[position - 1]
     altseq = refrseq + duplseq
 

--- a/kevlar/tests/test_gentrio.py
+++ b/kevlar/tests/test_gentrio.py
@@ -111,16 +111,19 @@ def test_gen_muts():
 
     testrefrs = [
         'T', 'A', 'GAGAGGGTTACATACGCAGAAAAAGACACACGCTACTGCCCCGCATAGCC', 'A',
-        'C', 'A', 'A', 'C', 'CCAATTAACGTGGAAGCTCGGGGTACCAGCGGACTTAGTGTTCCCGTCT'
-        'TCGGGTTTAATACTATACAGGCCGCAGATACGGCGAACGACGACCCCTTAATTAGACGTGAATTCACTT'
-        'TAGCATCCTTGCTCCTTCCGAAAGACCCCTATGGAAGCAACTCCCGAAACCCCGAAAGGT', 'C'
+        'C', 'A', 'AGTTTGTCGACCTCGAACTTGCCGCC', 'A', 'T', 'C'
     ]
     testalts = [
-        'C', 'C', 'G', 'C', 'G', 'ACGCGGCATTACTTTCCCTTTTAATCGCATCCAGTAGTTACGGT'
-        'GTAAGAGCTCGAGCGATTTTAGGTGTCAAAGGGAATTATTGAGGAAGTCTGGTATGCTGGGATAACCTG'
-        'TACATCGACGGAATCTACCACCCTACACGGCCTAATACTCCCCGTTCCGTATACTGTATAGGACCTATA'
+        'C', 'C', 'G', 'C', 'G', 'ACGCTGCATTACTTTCCCTTTTAATGGCATCCAGTAGTTACGGT'
+        'GTAAGAGCTCGAGCGATTTTAGGTGTCAAAGGGAATTATTGAGGAAGTATGGTATGCTGGGATGACCTG'
+        'TACATCGACGGAATCTACCACCCTACTCGGCCTAATACTCCCCGTTCCGTATACTGTATAGGACCTATA'
         'ATGGTTACTGACTGAACGAGTCCTACACTTCATGTCGCTGTAACATGGCGGATGTCCCAGTTGTTGTGC'
-        'CGATATTCCCAATCTGTAAGTGTTCTATTCCGGC', 'C', 'T', 'C', 'T'
+        'AGATATTCCCAATCTGTAAGAGTTCTCTTCTGGC', 'A', 'T', 'TTTTCCTTGAGCTGTCTAGTG'
+        'CCGTAGGTGAACCTCGTGGATATTAAGGCGTACGGACCATAGAGAGCTACCTCTAAGAGGTCCGGGGAT'
+        'AGGTTCCGGTCGTTGGTACACCCTGTATACCCCGCGACAGTTTTGAGGTCACAGCGTAGAGGGTGTAAC'
+        'GCAGTATGCAGGATTGGGATGGATGTGGACTTTGTATAGGTAGTATGTGTTTTTG', 'CAAATCGCCT'
+        'TTACCTAATCGACAAATAGGTTCCGTTGTACTTGCTCTAACCGTCGGTGATTTGAACACTTTCCATGTT'
+        'ACCACACTAG'
     ]
 
     assert refrs == testrefrs
@@ -153,16 +156,20 @@ def test_sim_var_geno():
     )
 
     variants = list(simulator)
-    print('DEBUG', variants, file=sys.stderr)
+    seqids = [v.seqid for v in variants]
+    positions = [v.position for v in variants]
+    genotypes = [v.genotypes for v in variants]
+
+    print('DEBUG', seqids, positions, genotypes)
 
     assert len(variants) == 4
-    assert [v.seqid for v in variants] == ['scaf3', 'scaf3', 'scaf2', 'scaf2']
-    assert [v.position for v in variants] == [4936, 57391, 23670, 99928]
-    assert [v.genotypes for v in variants] == [
+    assert seqids == ['scaf3', 'scaf3', 'scaf3', 'scaf1']
+    assert positions == [4936, 57391, 86540, 68352]
+    assert genotypes == [
         ('0/1', '0/1', '1/0'),
-        ('1/0', '1/1', '0/0'),
+        ('1/0', '0/1', '0/0'),
         ('0/1', '0/0', '0/0'),
-        ('1/0', '0/0', '0/0'),
+        ('0/1', '0/0', '0/0')
     ]
 
 
@@ -259,3 +266,9 @@ def test_gentrio_cli(capsys):
     outlines = out.strip().split('\n')
     numvariants = sum([1 for line in outlines if not line.startswith('#')])
     assert numvariants == 30
+
+
+def test_mutagenize():
+    rng = random.Random(1123581321)
+    mutseq = kevlar.gentrio.mutagenize('GATTACA' * 3, rng, rate=0.1)
+    assert mutseq == 'GATAACAGATTACAGATTACG'

--- a/kevlar/tests/test_gentrio.py
+++ b/kevlar/tests/test_gentrio.py
@@ -164,7 +164,7 @@ def test_sim_var_geno():
 
     assert len(variants) == 4
     assert seqids == ['scaf3', 'scaf3', 'scaf3', 'scaf1']
-    assert positions == [4936, 57391, 86540, 68352]
+    assert positions == [4936, 57390, 86540, 68352]
     assert genotypes == [
         ('0/1', '0/1', '1/0'),
         ('1/0', '0/1', '0/0'),

--- a/kevlar/tests/test_gentrio.py
+++ b/kevlar/tests/test_gentrio.py
@@ -73,6 +73,18 @@ def test_insertion(seq, pos, length, duplpos, refr, alt, rwindow, awindow):
     assert awindow == testaw
 
 
+def test_insertion_rng():
+    seq = 'ATGCCTATAGATTCAGTAGTTACCAGAGGCAGTGGTGTTTGCCACGCCATTTCTACGCGA'
+    rng = random.Random(2018)
+    refr, alt, refrwindow, altwindow = kevlar.gentrio.mutate_insertion(
+        seq, position=19, length=5, duplpos=44, rng=rng, ksize=11
+    )
+    assert refr == 'G'
+    assert alt == 'GCCCCA'
+    assert refrwindow == 'GATTCAGTAGTTACCAGAGG'
+    assert altwindow == 'GATTCAGTAGCCCCATTACCAGAGG'
+
+
 @pytest.mark.parametrize('seq,pos,length,refr,alt,rwindow,awindow', [
     ('AACTAGCCTGCGGTCTGTGTTTCCCGACTTCTGAGTCATGGGGTTTCAATGCCTAT',
      5, 9, 'AGCCTGCGGT', 'A', 'ACTAGCCTGCGGTCTGT', 'ACTACTGT'),
@@ -164,7 +176,7 @@ def test_sim_var_geno():
 
     assert len(variants) == 4
     assert seqids == ['scaf3', 'scaf3', 'scaf3', 'scaf1']
-    assert positions == [4936, 57390, 86540, 68352]
+    assert positions == [4936, 57391, 86540, 68352]
     assert genotypes == [
         ('0/1', '0/1', '1/0'),
         ('1/0', '0/1', '0/0'),


### PR DESCRIPTION
In previous variant simulations, insertions were composed of randomly generated DNA strings. The current version of `kevlar gentrio` will copy and paste a given region of the genome verbatim. This PR introduces a 5% mutation rate for duplicated sequences to make them a bit more of a realistic reflection of what we might expect to find in real human genomes.