### PR TITLE
Replace `KevlarNoReferenceMatchesError` with a runtime warning

### DIFF
--- a/kevlar/alac.py
+++ b/kevlar/alac.py
@@ -21,7 +21,8 @@ def alac(pstream, refrfile, ksize=31, delta=25, maxdiff=10000, match=1,
 
     for partition in pstream:
         contigs = [c for c in assembler(partition, logstream=logstream)]
-        targets = [t for t in localize(contigs, refrfile, ksize, delta=delta)]
+        targets = [t for t in localize(contigs, refrfile, ksize, delta=delta,
+                                       logstream=logstream)]
         caller = call(
             targets, contigs, match, mismatch, gapopen, gapextend, ksize
         )

--- a/kevlar/tests/test_localize.py
+++ b/kevlar/tests/test_localize.py
@@ -12,8 +12,7 @@ import pytest
 import screed
 import kevlar
 from kevlar.localize import KmerMatchSet
-from kevlar.localize import (KevlarRefrSeqNotFoundError,
-                             KevlarNoReferenceMatchesError)
+from kevlar.localize import KevlarRefrSeqNotFoundError
 from kevlar.localize import (extract_regions, get_unique_kmers,
                              unique_kmer_string)
 from kevlar.tests import data_file
@@ -144,10 +143,11 @@ def test_main(capsys):
     assert '>seq1_10-191' in out
 
 
-def test_main_no_matches():
+def test_main_no_matches(capsys):
     contig = data_file('localize-contig-bad.fa')
     refr = data_file('localize-refr.fa')
     arglist = ['localize', '--ksize', '23', contig, refr]
     args = kevlar.cli.parser().parse_args(arglist)
-    with pytest.raises(KevlarNoReferenceMatchesError) as nrm:
-        kevlar.localize.main(args)
+    kevlar.localize.main(args)
+    out, err = capsys.readouterr()
+    assert 'WARNING: no reference matches' in err


### PR DESCRIPTION
Turns out that raising an exception is unnecessary and problematic when trying to string `localize` together with other tools (such as in `alac` and `simplex`).