### PR TITLE
Fix bug with `kevlar alac` when there are no reference matches

### DIFF
--- a/kevlar/alac.py
+++ b/kevlar/alac.py
@@ -29,7 +29,7 @@ def alac(pstream, refrfile, ksize=31, delta=25, maxdiff=10000, match=1,
         reads = list(partition)
 
         # Assemble partitioned reads into contig(s)
-        contigs = [c for c in assembler(reads, logstream=logstream)]
+        contigs = list(assembler(reads, logstream=logstream))
         contigs = list(augment_and_mark(reads, contigs))
         if min_ikmers is not None:
             # Apply min ikmer filter if it's set

--- a/kevlar/tests/test_alac.py
+++ b/kevlar/tests/test_alac.py
@@ -87,8 +87,9 @@ def test_ikmer_filter_python():
     invoked.
     """
     readfile = data_file('min_ikmers_filt.augfastq.gz')
-    reads = kevlar.parse_augmented_fastx(readfile)
-    calls = list(kevlar.alac.alac(reads, 'BOGUSREFR', ksize=31, min_ikmers=3))
+    reads = kevlar.parse_augmented_fastx(kevlar.open(readfile, 'r'))
+    parts = kevlar.parse_partitioned_reads(reads)
+    calls = list(kevlar.alac.alac(parts, 'BOGUSREFR', ksize=31, min_ikmers=3))
 
 
 def test_ikmer_filter_cli():
@@ -96,3 +97,14 @@ def test_ikmer_filter_cli():
     arglist = ['alac', '--ksize', '31', '--min-ikmers', '3', reads, 'FAKEREFR']
     args = kevlar.cli.parser().parse_args(arglist)
     kevlar.alac.main(args)
+
+
+def test_no_reference_match(capsys):
+    readfile = data_file('pico-4.augfastq.gz')
+    reads = kevlar.parse_augmented_fastx(kevlar.open(readfile, 'r'))
+    partitions = kevlar.parse_partitioned_reads(reads)
+    refr = data_file('localize-refr.fa')
+    baldwin = kevlar.alac.alac(partitions, refr, logstream=sys.stderr)
+    calls = list(baldwin)
+    out, err = capsys.readouterr()
+    assert 'WARNING: no reference matches' in err


### PR DESCRIPTION
The `kevlar alac` procedure does not properly handle situations in which a contig has no k-mer matches against the reference genome. It is properly handled and reported by `kevlar localize`, but `kevlar alac` continues even when the list of potential targets for a contig contains 0 items.

```
$ time kevlar alac --delta 50 --ksize 45 PART/part.cc1357.augfastq.gz REFR/human_g1k_v37.fasta
[kevlar] running version 0.3.0+78.gb4b54ad
[kevlar::localize] WARNING: no reference matches
Traceback (most recent call last):
  File "/mnt/home/standage/anaconda3/envs/kevlar/bin/kevlar", line 11, in <module>
    load_entry_point('biokevlar==0.3.0+78.gb4b54ad', 'console_scripts', 'kevlar')()
  File "/mnt/home/standage/anaconda3/envs/kevlar/lib/python3.6/site-packages/kevlar/__main__.py", line 33, in main
    mainmethod(args)
  File "/mnt/home/standage/anaconda3/envs/kevlar/lib/python3.6/site-packages/kevlar/alac.py", line 57, in main
    for varcall in workflow:
  File "/mnt/home/standage/anaconda3/envs/kevlar/lib/python3.6/site-packages/kevlar/alac.py", line 42, in alac
    for varcall in caller:
  File "/mnt/home/standage/anaconda3/envs/kevlar/lib/python3.6/site-packages/kevlar/call.py", line 359, in call
    for varcall in make_call(besttarget, query, bestcigar, ksize):
  File "/mnt/home/standage/anaconda3/envs/kevlar/lib/python3.6/site-packages/kevlar/call.py", line 259, in make_call
    snvmatch = re.search('^(\d+)([DI])(\d+)M(\d+)[DI]$', cigar)
  File "/mnt/home/standage/anaconda3/envs/kevlar/lib/python3.6/re.py", line 182, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object
```

This PR fixes the bug.