### PR TITLE
Disable fallback by default

### DIFF
--- a/kevlar/alac.py
+++ b/kevlar/alac.py
@@ -17,7 +17,7 @@ from kevlar.call import call
 
 def alac(pstream, refrfile, ksize=31, bigpart=10000, delta=50, seedsize=31,
          maxdiff=10000, match=1, mismatch=2, gapopen=5, gapextend=0,
-         greedy=False, fallback=True, min_ikmers=None, logstream=sys.stderr):
+         greedy=False, fallback=False, min_ikmers=None, logstream=sys.stderr):
     assembler = assemble_greedy if greedy else assemble_fml_asm
     for partition in pstream:
         reads = list(partition)

--- a/kevlar/cli/alac.py
+++ b/kevlar/cli/alac.py
@@ -27,12 +27,10 @@ def subparser(subparsers):
     asmbl_args.add_argument('--greedy', action='store_true', help='Use a home-'
                             'grown greedy assembly algorithm instead of the '
                             'default fermi-lite algorithm')
-    asmbl_args.add_argument('--no-fallback', action='store_false',
-                            dest='fallback', help='by default, if fermi-lite '
-                            'fails to assemble a contig, `kevlar alac` will '
-                            'attempt to assemble reads with a home-grown '
-                            'greedy assembler; use this flag to deactivate '
-                            'this behavior')
+    asmbl_args.add_argument('--fallback', action='store_true', dest='fallback',
+                            help='attempt to assemble reads with a home-grown '
+                            'greedy assembly algorithm if fermi-lite fails to '
+                            'assemble a contig for a partition')
 
     local_args = subparser.add_argument_group('Target extraction')
     local_args.add_argument('-z', '--seed-size', type=int, default=51,

--- a/kevlar/simplex.py
+++ b/kevlar/simplex.py
@@ -20,7 +20,7 @@ def simplex(case, casecounts, controlcounts, refrfile, ctrlmax=0, casemin=5,
             mask=None, filtermem=1e6, filterfpr=0.001,
             partminabund=2, partmaxabund=200, dedup=True,
             delta=50, seedsize=31, match=1, mismatch=2, gapopen=5, gapextend=0,
-            ksize=31, logstream=sys.stderr):
+            fallback=False, ksize=31, logstream=sys.stderr):
     """
     Execute the simplex germline variant discovery workflow.
 
@@ -55,6 +55,8 @@ def simplex(case, casecounts, controlcounts, refrfile, ctrlmax=0, casemin=5,
     - mismatch: alignment mismatch penalty
     - gapopen: alignment gap open penalty
     - gapextend: alignment gap extension penalty
+    - fallback: try assembly with home-grown greedy assembly algorithm if
+                assembly with fermi-lite fails for a partition
     """
     discoverer = novel(
         case, [casecounts], controlcounts, ksize=ksize, casemin=casemin,
@@ -72,7 +74,7 @@ def simplex(case, casecounts, controlcounts, refrfile, ctrlmax=0, casemin=5,
     caller = alac(
         partitioner, refrfile, ksize=ksize, delta=delta, seedsize=seedsize,
         match=match, mismatch=mismatch, gapopen=gapopen, gapextend=gapextend,
-        logstream=logstream
+        fallback=fallback, logstream=logstream
     )
 
     for variant in caller:

--- a/kevlar/tests/test_alac.py
+++ b/kevlar/tests/test_alac.py
@@ -156,7 +156,7 @@ def test_alac_inf_mate_dist(cc, numrawcalls):
     readstream = kevlar.parse_augmented_fastx(kevlar.open(readfile, 'r'))
     partstream = kevlar.parse_partitioned_reads(readstream)
     caller = kevlar.alac.alac(partstream, refrfile, ksize=31, delta=50,
-                              seedsize=51)
+                              seedsize=51, fallback=True)
     calls = list(caller)
     print(*[c.vcf for c in calls], sep='\n', file=sys.stderr)
     assert len(calls) in numrawcalls
@@ -171,7 +171,7 @@ def test_alac_no_mates():
     readstream = kevlar.parse_augmented_fastx(kevlar.open(readfile, 'r'))
     partstream = kevlar.parse_partitioned_reads(readstream)
     caller = kevlar.alac.alac(partstream, refrfile, ksize=31, delta=50,
-                              seedsize=51)
+                              seedsize=51, fallback=True)
     calls = list(caller)
     print(*[c.vcf for c in calls], sep='\n', file=sys.stderr)
     assert len(calls) in [3, 5, 7]


### PR DESCRIPTION
The assembly fallback strategy was introduced to address a problem observed with simulated genomes. For some read partitions, fermi-lite failed to assemble anything whereas our homegrown greedy assembler produced a contig just fine. Using this strategy we were able to achieve perfect sensitivity for all of our simulated genomes. This came at the cost of several false calls, which I have been attempting to compensate for using other means.

With real data, however, things have played out a bit differently. The fallback strategy seems to be introducing an inordinate number of false calls without improving sensitivity in any way I can measure.

This PR keeps the fallback strategy around, but disables it by default.