### PR TITLE
Remove junction count assembler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bug with `kevlar count` when reading from multiple input files (see #202).
 - Can now call SNVs near INDELs (see #229).
 
+### Removed
+- The JCA assembly mode is no longer supported (see #231).
+
+
 ## [0.3.0] - 2017-11-03
 
 This release includes many new features, some refactoring of the core codebase, and the first end-to-end analysis workflow implemented in a single command.

--- a/kevlar/cli/assemble.py
+++ b/kevlar/cli/assemble.py
@@ -13,10 +13,11 @@ import khmer
 def subparser(subparsers):
     """Define the `kevlar assemble` command-line interface."""
 
-    desc = ('Assemble reads into contigs representing putative variants. By '
-            'default `fermi-lite` is used to compute the assembly, but two '
-            'alternative assembly algorithms are available.')
-
+    desc = (
+        'Assemble reads into contigs representing putative variants. By '
+        'default `fermi-lite` is used to compute the assembly, but an '
+        'alternative assembly algorithm is available.'
+    )
     subparser = subparsers.add_parser('assemble', description=desc,
                                       add_help=False)
 
@@ -41,27 +42,6 @@ def subparser(subparsers):
                              default=500, help='discard interesting k-mers '
                              'that occur more than X times')
 
-    jca_args = subparser.add_argument_group(
-        'Junction count assembly mode',
-        'Alternatively, `kevlar assemble` can uses a junction count assembler '
-        'available from the khmer library.'
-    )
-    jca_args.add_argument('--jca', action='store_true', help="use khmer's "
-                          "junction count assembler instead of kevlar's "
-                          "greedy assembler")
-    jca_args.add_argument('--ignore', metavar='KM', nargs='+',
-                          help='ignore the specified k-mer(s)')
-    jca_args.add_argument('--collapse', action='store_true', help='collapse '
-                          'contigs that are contained within other contigs')
-    jca_args.add_argument('-M', '--memory', default='1e6', metavar='MEM',
-                          type=khmer.khmer_args.memory_setting,
-                          help='memory to allocate for assembly graph; '
-                          'default is 1M')
-    jca_args.add_argument('--max-fpr', type=float, metavar='FPR',
-                          default=0.001, help='terminate if the expected '
-                          'false positive rate of the assembly graph is '
-                          'higher than the specified FPR; default is 0.001')
-
     misc_args = subparser.add_argument_group('Miscellaneous settings')
     misc_args.add_argument('-h', '--help', action='help',
                            help='show this help message and exit')
@@ -69,4 +49,4 @@ def subparser(subparsers):
                            help='output file; default is terminal (stdout)')
 
     subparser.add_argument('augfastq', help='annotated reads in augmented '
-                           'Fastq format')
+                           'Fastq/Fasta format')

--- a/kevlar/tests/test_assemble.py
+++ b/kevlar/tests/test_assemble.py
@@ -517,28 +517,10 @@ def test_assembly_contigs():
                                   'TGGCTAACACG')
 
 
-@pytest.mark.parametrize('jcamode', [
-    (True),
-    (False),
-])
-def test_assemble_main(jcamode, capsys):
+def test_assemble_main(capsys):
     cliargs = ['assemble', data_file('var1.reads.augfastq')]
     args = kevlar.cli.parser().parse_args(cliargs)
-    args.jca = jcamode
     kevlar.assemble.main(args)
-    out, err = capsys.readouterr()
-    contig = ('GTCCTTGAGTCCATTAGAGACGGCTTCCGCCGTAGGCCCACTTCCTTAAAGTCGAGACTTCTA'
-              'AAAACCGGGGTGTAACTCTTTTATTACAAAGCGACTATCCACCTGTAAGGACAGTGATA')
-    print('DEBUG', contig)
-    print('DEBUG', out)
-    assert contig in out or kevlar.revcom(contig) in out
-
-
-def test_assemble_jca_collapse(capsys):
-    infile = data_file('var1.reads.augfastq')
-    cliargs = ['assemble', '--jca', '--collapse', infile]
-    args = kevlar.cli.parser().parse_args(cliargs)
-    kevlar.__main__.main(args)
     out, err = capsys.readouterr()
     contig = ('GTCCTTGAGTCCATTAGAGACGGCTTCCGCCGTAGGCCCACTTCCTTAAAGTCGAGACTTCTA'
               'AAAACCGGGGTGTAACTCTTTTATTACAAAGCGACTATCCACCTGTAAGGACAGTGATA')


### PR DESCRIPTION
The JCA assembly mode hasn't been used actively for a long time. The greedy assembly mode, though buggy, seemed to perform better. But even though we are retaining this for fallback mode, there's some evidence that fallback mode does more harm than good in most scenarios (more false positives without any real gains).

This PR removes the JCA mode.