### PR TITLE
Report partition label in VCF output

### DIFF
--- a/kevlar/tests/test_alac.py
+++ b/kevlar/tests/test_alac.py
@@ -119,6 +119,7 @@ def test_alac_single_partition(label, position):
     calls = list(kevlar.alac.alac(partstream, refrfile))
     assert len(calls) == 1
     assert calls[0].position == position - 1
+    assert calls[0].attribute('PART') == label
 
 
 def test_alac_single_partition_badlabel(capsys):


### PR DESCRIPTION
Sometimes kevlar makes multiple variant calls from a single partition. Typically this is because an inherited variant is proximal to a novel variant. In any case, we expect only a single novel variant from each partition. This PR reports the partition label for each call to aid in troubleshooting and results interpretation.