### PR TITLE
Fix reported mateseq distances

### DIFF
--- a/kevlar/call.py
+++ b/kevlar/call.py
@@ -40,7 +40,8 @@ def mate_distance(mate_positions, gdna_position):
         if seqid != gdnaseq:
             continue
         d = pointdist(pos)
-        distances.append(d)
+        if d < 10000:
+            distances.append(d)
     if len(distances) == 0:
         return float('Inf')
     return sum(distances) / len(distances)

--- a/kevlar/reference.py
+++ b/kevlar/reference.py
@@ -66,6 +66,11 @@ def bwa_align(cmdargs, seqstring):
                 continue
             seqid = sam.get_reference_name(record.reference_id)
             yield seqid, record.pos
+            if record.has_tag('XA'):
+                alts = record.get_tag('XA').strip(';').split(';')
+                for alt in alts:
+                    seqid, pos = re.search(r'^([^,]+),[+-](\d+)', alt).groups()
+                    yield seqid, int(pos)
 
 
 class ReferenceCutout(object):

--- a/kevlar/varmap.py
+++ b/kevlar/varmap.py
@@ -198,7 +198,7 @@ class VariantMapping(object):
                 nocall = Variant(
                     self.seqid, self.cutout.local_to_global(offset), '.', '.',
                     CONTIG=qseq, CIGAR=self.cigar, KSW2=str(self.score),
-                    IKMERS=len(self.contig.ikmers)
+                    IKMERS=str(len(self.contig.ikmers))
                 )
                 nocall.filter(vf.PerfectMatch)
                 yield nocall

--- a/kevlar/vcf.py
+++ b/kevlar/vcf.py
@@ -106,6 +106,7 @@ class Variant(object):
         return self.attribute('REFRWINDOW')
 
     def annotate(self, key, value):
+        value = str(value)
         if key in self.info:
             if isinstance(self.info[key], set):
                 self.info[key].add(value)


### PR DESCRIPTION
In addressing #244, this PR introduces two new changes.

- When aligning mate reads, scan the `XA` tag of the alignment for alternative alignments that may be informative.
- Discard any mate read alignment that is > 10kb from the locus of interest (could be parametrized, but is not yet).

Closes #244.