### PR TITLE
Implemented multithreading for "kevlar alac"

### DIFF
--- a/kevlar/alac.py
+++ b/kevlar/alac.py
@@ -12,6 +12,7 @@ from queue import Queue
 import re
 import sys
 from threading import Thread
+from time import sleep
 
 import kevlar
 from kevlar.assemble import assemble_greedy, assemble_fml_asm
@@ -24,6 +25,9 @@ def make_call_from_reads(queue, idx, calls, refrfile, ksize=31, delta=50,
                          gapopen=5, gapextend=0, greedy=False, fallback=False,
                          min_ikmers=None, refrseqs=None, logstream=sys.stderr):
         while True:
+            if queue.empty():
+                sleep(1)
+                continue
             reads = queue.get()
             ccmatch = re.search(r'kvcc=(\d+)', reads[0].name)
             cc = ccmatch.group(1) if ccmatch else None
@@ -74,7 +78,7 @@ def alac(pstream, refrfile, threads=1, ksize=31, bigpart=10000, delta=50,
          seedsize=31, maxdiff=None, match=1, mismatch=2, gapopen=5,
          gapextend=0, greedy=False, fallback=False, min_ikmers=None,
          logstream=sys.stderr):
-    part_queue = Queue(maxsize=max(12, 3 * threads))
+    part_queue = Queue(maxsize=max(32, 12 * threads))
 
     refrstream = kevlar.open(refrfile, 'r')
     refrseqs = kevlar.seqio.parse_seq_dict(refrstream)

--- a/kevlar/alac.py
+++ b/kevlar/alac.py
@@ -26,7 +26,7 @@ def make_call_from_reads(queue, idx, calls, refrfile, ksize=31, delta=50,
                          min_ikmers=None, refrseqs=None, logstream=sys.stderr):
         while True:
             if queue.empty():
-                sleep(1)
+                sleep(3)
                 continue
             reads = queue.get()
             ccmatch = re.search(r'kvcc=(\d+)', reads[0].name)
@@ -42,7 +42,7 @@ def make_call_from_reads(queue, idx, calls, refrfile, ksize=31, delta=50,
             contigs = list(assmblr(reads, logstream=logstream))
             if len(contigs) == 0 and assmblr == assemble_fml_asm and fallback:
                 message = 'WARNING: no contig assembled by fermi-lite'
-                if cc:
+                if cc:  # pragma: no cover
                     message += ' for partition={:s}'.format(cc)
                 message += '; attempting again with homegrown greedy assembler'
                 print('[kevlar::alac]', message, file=logstream)

--- a/kevlar/alac.py
+++ b/kevlar/alac.py
@@ -27,7 +27,8 @@ def make_call_from_reads(queue, idx, calls, refrfile, ksize=31, delta=50,
             reads = queue.get()
             ccmatch = re.search(r'kvcc=(\d+)', reads[0].name)
             cc = ccmatch.group(1) if ccmatch else None
-            message = '[kevlar::alac::make_call_from_reads ({:d})]'.format(idx)
+            message = '[kevlar::alac::make_call_from_reads'
+            message += ' (thread={:d})]'.format(idx)
             message += ' grabbed partition={} from queue,'.format(cc)
             message += ' queue size now {:d}'.format(queue.qsize())
             print(message, file=sys.stderr)
@@ -99,6 +100,8 @@ def alac(pstream, refrfile, threads=1, ksize=31, bigpart=10000, delta=50,
             message = 'skipping partition with {:d} reads'.format(len(reads))
             print('[kevlar::alac] WARNING:', message, file=logstream)
             continue
+        message = 'adding partition with {} reads to queue'.format(len(reads))
+        print('[kevlar::alac]', message, file=logstream)
         part_queue.put(reads)
 
     part_queue.join()

--- a/kevlar/cli/alac.py
+++ b/kevlar/cli/alac.py
@@ -67,6 +67,9 @@ def subparser(subparsers):
                            'supported by fewer than `I` interesting k-mers')
     misc_args.add_argument('-k', '--ksize', type=int, default=31, metavar='K',
                            help='k-mer size; default is 31')
+    misc_args.add_argument('-t', '--threads', type=int, default=1, metavar='T',
+                           help='process T partitions at a time using T '
+                           'threads')
     subparser.add_argument('infile', help='partitioned reads in augmented '
                            'Fastq format')
     subparser.add_argument('refr', help='reference genome in Fasta format '

--- a/kevlar/cli/simplex.py
+++ b/kevlar/cli/simplex.py
@@ -68,7 +68,8 @@ def subparser(subparsers):
     )
     novel_args.add_argument(
         '-t', '--threads', type=int, default=1, metavar='T', help='number of '
-        'threads to use for processing FASTA/FASTQ files; default is 1'
+        'threads to use for processing FASTA/FASTQ files, assembling reads, '
+        'and calling variants; default is 1'
     )
 
     filter_args = subparser.add_argument_group(

--- a/kevlar/simplex.py
+++ b/kevlar/simplex.py
@@ -20,7 +20,7 @@ def simplex(case, casecounts, controlcounts, refrfile, ctrlmax=0, casemin=5,
             mask=None, filtermem=1e6, filterfpr=0.001,
             partminabund=2, partmaxabund=200, dedup=True,
             delta=50, seedsize=31, match=1, mismatch=2, gapopen=5, gapextend=0,
-            fallback=False, ksize=31, logstream=sys.stderr):
+            fallback=False, ksize=31, threads=1, logstream=sys.stderr):
     """
     Execute the simplex germline variant discovery workflow.
 
@@ -72,9 +72,9 @@ def simplex(case, casecounts, controlcounts, refrfile, ctrlmax=0, casemin=5,
     )
 
     caller = alac(
-        partitioner, refrfile, ksize=ksize, delta=delta, seedsize=seedsize,
-        match=match, mismatch=mismatch, gapopen=gapopen, gapextend=gapextend,
-        fallback=fallback, logstream=logstream
+        partitioner, refrfile, threads=threads, ksize=ksize, delta=delta,
+        seedsize=seedsize, match=match, mismatch=mismatch, gapopen=gapopen,
+        gapextend=gapextend, fallback=fallback, logstream=logstream
     )
 
     for variant in caller:
@@ -110,7 +110,7 @@ def main(args):
         partminabund=args.part_min_abund, partmaxabund=args.part_max_abund,
         dedup=args.dedup, delta=args.delta, seedsize=args.seed_size,
         match=args.match, mismatch=args.mismatch, gapopen=args.open,
-        gapextend=args.extend, logstream=args.logfile
+        gapextend=args.extend, threads=args.threads, logstream=args.logfile
     )
     for variant in workflow:
         print(variant.vcf, file=outstream)

--- a/kevlar/tests/test_alac.py
+++ b/kevlar/tests/test_alac.py
@@ -80,19 +80,21 @@ def test_ikmer_filter_python():
     Smoke test for filtering based in number of supporting ikmers.
 
     Each partition in the data set has only 2 supporting interesting k-mers.
-    The supplied reference file doesn't exist, so if this test passes it's
-    because the filtering worked correctly and the `localize` code is never
-    invoked.
+    The supplied reference file doesn't actually correspond to the reads, so if
+    this test passes it's because the filtering worked correctly and the
+    `localize` code is never invoked.
     """
     readfile = data_file('min_ikmers_filt.augfastq.gz')
     reads = kevlar.parse_augmented_fastx(kevlar.open(readfile, 'r'))
     parts = kevlar.parse_partitioned_reads(reads)
-    calls = list(kevlar.alac.alac(parts, 'BOGUSREFR', ksize=31, min_ikmers=3))
+    refr = data_file('localize-refr.fa')
+    calls = list(kevlar.alac.alac(parts, refr, ksize=31, min_ikmers=3))
 
 
 def test_ikmer_filter_cli():
     reads = data_file('min_ikmers_filt.augfastq.gz')
-    arglist = ['alac', '--ksize', '31', '--min-ikmers', '3', reads, 'FAKEREFR']
+    refr = data_file('localize-refr.fa')
+    arglist = ['alac', '--ksize', '31', '--min-ikmers', '3', reads, refr]
     args = kevlar.cli.parser().parse_args(arglist)
     kevlar.alac.main(args)
 


### PR DESCRIPTION
This PR implements multithreading for `kevlar alac` so that in the future we will not have to split the input and unvoke N separate `kevlar alac` runs. The primary thread loads reads into a queue partition-by-partition, and N worker threads pull reads off the queue and invoke the "alac" (assemble, localize, align, & call) procedure. Variant calls are accumulated into N distinct lists, which are collapsed and sorted after the threads are joined.

Hat tip to @camillescott and @ctb for helpful discussions on the topic.