### PR TITLE
Reporting all seed matches

### DIFF
--- a/kevlar/localize.py
+++ b/kevlar/localize.py
@@ -107,7 +107,9 @@ def get_exact_matches(contigstream, bwaindexfile, seedsize=31):
     (seqid, startpos) for each exact match found.
     """
     kmers = unique_seed_string(contigstream, seedsize)
-    cmd = 'bwa mem -k {k} -T {k} {idx} -'.format(k=seedsize, idx=bwaindexfile)
+    cmd = 'bwa mem -k {k} -T {k} -a -c 5000 {idx} -'.format(
+        k=seedsize, idx=bwaindexfile
+    )
     cmdargs = cmd.split(' ')
     for seqid, pos in bwa_align(cmdargs, seqstring=kmers):
         yield seqid, pos

--- a/kevlar/tests/test_alac.py
+++ b/kevlar/tests/test_alac.py
@@ -147,11 +147,11 @@ def test_alac_bigpart():
     assert len(calls) == 3
 
 
-@pytest.mark.parametrize('cc,numrawcalls', [
-    ('26849', [3, 4, 5, 7]),  # Assembly deterministic on OS X, but not Linux
-    ('138713', [14]),
+@pytest.mark.parametrize('cc,numrawcalls,numfiltcalls', [
+    ('26849', 4, 2),
+    ('138713', 14, 1),
 ])
-def test_alac_inf_mate_dist(cc, numrawcalls):
+def test_alac_inf_mate_dist(cc, numrawcalls, numfiltcalls):
     readfile = data_file('inf-mate-dist/cc{}.augfastq.gz'.format(cc))
     refrfile = data_file('inf-mate-dist/cc{}.genome.fa.gz'.format(cc))
     readstream = kevlar.parse_augmented_fastx(kevlar.open(readfile, 'r'))
@@ -160,10 +160,9 @@ def test_alac_inf_mate_dist(cc, numrawcalls):
                               seedsize=51, fallback=True)
     calls = list(caller)
     print(*[c.vcf for c in calls], sep='\n', file=sys.stderr)
-    assert len(calls) in numrawcalls
+    assert len(calls) == numrawcalls
     filtcalls = [c for c in calls if c.filterstr == 'PASS']
-    print(*[c.vcf for c in filtcalls], sep='\n', file=sys.stderr)
-    assert len(filtcalls) == 1
+    assert len(filtcalls) == numfiltcalls
 
 
 def test_alac_no_mates():
@@ -175,16 +174,16 @@ def test_alac_no_mates():
                               seedsize=51, fallback=True)
     calls = list(caller)
     print(*[c.vcf for c in calls], sep='\n', file=sys.stderr)
-    assert len(calls) in [3, 4, 5, 7]
+    assert len(calls) == 4
     filtcalls = [c for c in calls if c.filterstr == 'PASS']
-    assert len(filtcalls) == 2
+    assert len(filtcalls) == 3
 
 
 @pytest.mark.parametrize('vcfposition,X,cigar', [
-    (40692, 10000, '30595D96M6I91M15137D'),
-    (40692, 1000, '37D96M6I91M44D'),
-    (40692, 0, '30595D96M6I91M132906D'),
-    (40692, None, '37D96M6I91M44D'),
+    (40692, 10000, '32713D96M6I91M15142D'),
+    (40692, 1000, '50D96M6I91M50D'),
+    (40692, 0, '32713D96M6I91M140025D'),
+    (40692, None, '50D96M6I91M50D'),
 ])
 def test_alac_maxdiff(vcfposition, X, cigar):
     pstream = kevlar.parse_partitioned_reads(

--- a/kevlar/tests/test_localize.py
+++ b/kevlar/tests/test_localize.py
@@ -163,9 +163,9 @@ def test_extract_regions_boundaries():
 @pytest.mark.parametrize('X,numtargets', [
     (100000, 1),
     (10000, 5),
-    (1000, 23),
+    (1000, 33),
     (0, 1),
-    (None, 23),
+    (None, 33),
 ])
 def test_maxdiff(X, numtargets):
     contigstream = kevlar.parse_augmented_fastx(


### PR DESCRIPTION
While evaluating kevlar's performance on some simulated data sets, I have found several cases where the correct locus of a variant could not be found. In some rare circumstances I've also seen some non-deterministic behavior with the assemble/localize/align/call procedure. I'm suspicious that not reporting all seed exact matches in the genome is at the heart of these issues.

This PR updates the system call to find seed exact matches in the genome and ensures that all exact matches are reported.