### PR TITLE
Do not filter with mate distance before likelihood is calculated

### DIFF
--- a/kevlar/call.py
+++ b/kevlar/call.py
@@ -125,8 +125,6 @@ def prelim_call(targetlist, querylist, match=1, mismatch=2, gapopen=5,
             for varcall in alignment.call_variants(ksize, mindist, logstream):
                 if alignment.matedist:
                     varcall.annotate('MD', '{:.2f}'.format(alignment.matedist))
-                    if n > 0:
-                        varcall.filter(vf.MateFail)
                 yield varcall
 
 

--- a/kevlar/tests/test_alac.py
+++ b/kevlar/tests/test_alac.py
@@ -147,11 +147,11 @@ def test_alac_bigpart():
     assert len(calls) == 3
 
 
-@pytest.mark.parametrize('cc,numrawcalls,numfiltcalls', [
-    ('26849', 4, 2),
-    ('138713', 14, 1),
+@pytest.mark.parametrize('cc,numcalls,numdist,numinf', [
+    ('26849', 4, 2, 0),
+    ('138713', 14, 14, 10),
 ])
-def test_alac_inf_mate_dist(cc, numrawcalls, numfiltcalls):
+def test_alac_inf_mate_dist(cc, numcalls, numdist, numinf):
     readfile = data_file('inf-mate-dist/cc{}.augfastq.gz'.format(cc))
     refrfile = data_file('inf-mate-dist/cc{}.genome.fa.gz'.format(cc))
     readstream = kevlar.parse_augmented_fastx(kevlar.open(readfile, 'r'))
@@ -159,10 +159,13 @@ def test_alac_inf_mate_dist(cc, numrawcalls, numfiltcalls):
     caller = kevlar.alac.alac(partstream, refrfile, ksize=31, delta=50,
                               seedsize=51, fallback=True)
     calls = list(caller)
-    print(*[c.vcf for c in calls], sep='\n', file=sys.stderr)
-    assert len(calls) == numrawcalls
-    filtcalls = [c for c in calls if c.filterstr == 'PASS']
-    assert len(filtcalls) == numfiltcalls
+    withdist = [c for c in calls if c.attribute('MD') is not None]
+    infdist = [c for c in calls if c.attribute('MD') == 'inf']
+    print('DEBUG total withdist infdist', len(calls), len(withdist),
+          len(infdist), file=sys.stderr)
+    assert len(calls) == numcalls
+    assert len(withdist) == numdist
+    assert len(infdist) == numinf
 
 
 def test_alac_no_mates():


### PR DESCRIPTION
The average distance of mapped mate reads seems to be informative when kevlar needs to select between multiple potential loci. Currently `kevlar call` filters out all putative calls except those with the shortest mate distance. This PR disables the filter but keeps the calculated distances, perhaps to be used later after likelihoods are calculated.