### PR TITLE
New `SpuriousMismatch` filter

### DIFF
--- a/kevlar/varmap.py
+++ b/kevlar/varmap.py
@@ -195,6 +195,9 @@ class VariantMapping(object):
             for call in chain(leftflankcaller, rightflankcaller):
                 if self.is_passenger(call):
                     call.filter(vf.PassengerVariant)
+                if abs(call.position - indel.position) > ksize and \
+                        int(call.attribute('IKMERS')) < ksize / 4:
+                    call.filter(vf.SpuriousMismatch)
                 yield call
         else:
             nocall = Variant(

--- a/kevlar/vcf.py
+++ b/kevlar/vcf.py
@@ -17,6 +17,7 @@ class VariantFilter(Enum):
     InscrutableCigar = 2
     PassengerVariant = 3
     MateFail = 4
+    SpuriousMismatch = 5
 
 
 class Variant(object):


### PR DESCRIPTION
A contig/refrtarget mapping classified as an indel may also have SNVs in the "match" blocks flanking the indel. If no interesting k-mers span these SNVs they are labeled as "passenger" variants, or vice versa if no interesting k-mers span the indel.

This PR introduces a new filter that marks SNVs near indels as "spurious mismatches" if 1) they are more than `k` nucleotides away from the indel, and 2) if they have few supporting k-mers.

I'm not 100% sure this is a good idea, but it provides a slight improvement in accuracy for a data set simulated on chr17.