### PR TITLE
Improve performance by caching k-mer abundance query results

### DIFF
--- a/kevlar/novel.py
+++ b/kevlar/novel.py
@@ -121,6 +121,9 @@ def novel(casestream, casecounts, controlcounts, ksize=31, abundscreen=None,
         message += ' (`numbands` - 1), inclusive'
         raise ValueError(message)
 
+    casecounts = tuple(casecounts)
+    controlcounts = tuple(controlcounts)
+
     timer = kevlar.Timer()
     timer.start()
     nkmers = 0

--- a/kevlar/novel.py
+++ b/kevlar/novel.py
@@ -7,6 +7,7 @@
 # licensed under the MIT license: see LICENSE.
 # -----------------------------------------------------------------------------
 
+from functools import lru_cache
 import re
 import sys
 
@@ -19,6 +20,7 @@ class KevlarCaseSampleMismatchError(ValueError):
     pass
 
 
+@lru_cache(maxsize=16384)
 def kmer_is_interesting(kmer, casecounts, controlcounts, case_min=5,
                         ctrl_max=1, screen_thresh=None):
     """


### PR DESCRIPTION
Related to #208, this pull request uses the `lru_cache` decorator to cache results from every invocation of `kmer_is_interesting` function. With a sufficiently large cache, a k-mer (especially repetitive k-mers) in multiple nearby reads should require only a single invocation of the command. Subsequent invocations with the same arguments will pull from the lru_cache instead of re-executing the command.

Preliminary results aren't too promising. The cost of caching results doesn't seem to compensate for the savings gained by avoiding repeat calls.