### PR TITLE
Counter size and mask support for kevlar count

### DIFF
--- a/kevlar/cli/count.py
+++ b/kevlar/cli/count.py
@@ -53,6 +53,14 @@ def subparser(subparsers):
                            metavar='FPR', help='terminate if the estimated '
                            'false positive rate for any sample is higher than '
                            '"FPR"; default is 0.2')
+    subparser.add_argument('--mask', metavar='MSK', help='counttable or '
+                           'nodetable of k-mers to ignore when counting '
+                           'k-mers')
+    subparser.add_argument('--count-masked', action='store_true',
+                           help='by default, when a mask is provided k-mers '
+                           'in the mask are ignored; this setting inverts the '
+                           'behavior so that only k-mers in the mask are '
+                           'counted')
     subparser.add_argument('--num-bands', type=int, metavar='N', default=None,
                            help='number of bands into which to divide the '
                            'hashed k-mer space')

--- a/kevlar/cli/count.py
+++ b/kevlar/cli/count.py
@@ -41,6 +41,11 @@ def subparser(subparsers):
 
     subparser.add_argument('-k', '--ksize', type=int, default=31, metavar='K',
                            help='k-mer size; default is 31')
+    subparser.add_argument('-c', '--counter-size', type=int, choices=(1, 4, 8),
+                           metavar='C', default=8, help='number of bits to '
+                           'allocate for counting each k-mer; options are 1 '
+                           '(max count: 1), 4 (max count: 15), and 8 (max '
+                           'count: 255); default is 8)')
     subparser.add_argument('-M', '--memory', type=khmer_args.memory_setting,
                            default=1e6, metavar='MEM',
                            help='memory to allocate for the count table')

--- a/kevlar/count.py
+++ b/kevlar/count.py
@@ -12,20 +12,21 @@ import threading
 import sys
 import khmer
 import kevlar
+from kevlar.sketch import allocate, get_extension
 
 
-def load_sample_seqfile(seqfiles, ksize, memory, maxfpr=0.2,
-                        mask=None, maskmaxabund=1, numbands=None, band=None,
-                        outfile=None, numthreads=1, logfile=sys.stderr):
-    """
-    Compute k-mer abundances for the specified sequence input.
+def load_sample_seqfile(seqfiles, ksize, memory, maxfpr=0.2, count=True,
+                        smallcount=False, mask=None, maskmaxabund=1,
+                        numbands=None, band=None, outfile=None, numthreads=1,
+                        logfile=sys.stderr):
+    """Compute k-mer abundances for the specified sequence input.
 
     Expected input is a list of one or more FASTA/FASTQ files corresponding
-    to a single sample. A counttable is created and populated with abundances
+    to a single sample. A sketch is created and populated with abundances
     of all k-mers observed in the input. If `mask` is provided, only k-mers not
     present in the mask will be loaded.
     """
-    sketch = khmer.Counttable(ksize, memory / 4, 4)
+    sketch = allocate(ksize, memory / 4, count=count, smallcount=smallcount)
     numreads = 0
     for seqfile in seqfiles:
         print('[kevlar::count]      loading from', seqfile, file=logfile)
@@ -74,8 +75,9 @@ def load_sample_seqfile(seqfiles, ksize, memory, maxfpr=0.2,
         raise kevlar.sketch.KevlarUnsuitableFPRError(message)
 
     if outfile:
-        if not outfile.endswith(('.ct', '.counttable')):
-            outfile += '.counttable'
+        extensions = get_extension(count=count, smallcount=smallcount)
+        if not outfile.endswith(extensions):
+            outfile += extensions[1]
         sketch.save(outfile)
         message += ';\n    saved to "{:s}"'.format(outfile)
     print('[kevlar::count]    ', message, file=logfile)
@@ -91,10 +93,12 @@ def main(args):
     timer = kevlar.Timer()
     timer.start()
 
+    docount = args.counter_size > 1
+    dosmallcount = args.counter_size == 4
     sketch = load_sample_seqfile(
-        args.seqfile, args.ksize, args.memory, args.max_fpr,
-        numbands=args.num_bands, band=myband, numthreads=args.threads,
-        outfile=args.counttable, logfile=args.logfile
+        args.seqfile, args.ksize, args.memory, args.max_fpr, count=docount,
+        smallcount=dosmallcount, numbands=args.num_bands, band=myband,
+        numthreads=args.threads, outfile=args.counttable, logfile=args.logfile
     )
 
     total = timer.stop()

--- a/kevlar/sketch.py
+++ b/kevlar/sketch.py
@@ -26,6 +26,30 @@ sketch_loader_by_filename_extension = {
     '.smallcountgraph': khmer.SmallCountgraph.load,
 }
 
+# count(?)->graph(?)->small(?)
+sketch_extensions_by_trait = {
+    True: {
+        True: {
+            True: ('.scg', '.smallcountgraph'),
+            False: ('.cg', '.countgraph'),
+        },
+        False: {
+            True: ('.sct', '.smallcounttable'),
+            False: ('.ct', '.counttable'),
+        },
+    },
+    False: {
+        True: {
+            True: ('.ng', '.nodegraph'),
+            False: ('.ng', '.nodegraph'),
+        },
+        False: {
+            True: ('.nt', '.nodetable'),
+            False: ('.nt', '.nodetable'),
+        },
+    },
+}
+
 
 class KevlarSketchTypeError(ValueError):
     pass
@@ -66,6 +90,10 @@ def load(filename):
     ext = '.' + filename.split('.')[-1]
     loadfunc = sketch_loader_by_filename_extension[ext]
     return loadfunc(filename)
+
+
+def get_extension(count=False, graph=False, smallcount=False):
+    return sketch_extensions_by_trait[count][graph][smallcount]
 
 
 def allocate(ksize, target_tablesize, num_tables=4, count=False, graph=False,

--- a/kevlar/tests/test_sketch.py
+++ b/kevlar/tests/test_sketch.py
@@ -10,6 +10,7 @@
 import pytest
 import khmer
 import kevlar
+from kevlar.sketch import get_extension
 from kevlar.tests import data_file, data_glob
 
 
@@ -97,3 +98,10 @@ def test_load_sketches_fpr_fail():
     with pytest.raises(kevlar.sketch.KevlarUnsuitableFPRError) as e:
         sketches = kevlar.sketch.load_sketchfiles(infiles, maxfpr=0.001)
     assert 'FPR too high, bailing out!!!' in str(e)
+
+
+def test_get_extensions():
+    assert get_extension() == ('.nt', '.nodetable')
+    assert get_extension(count=True) == ('.ct', '.counttable')
+    assert get_extension(count=True, smallcount=True) == ('.sct',
+                                                          '.smallcounttable')


### PR DESCRIPTION
Currently `kevlar count` creates only Counttable objects. This PR introduces options for creating SmallCounttable and Nodetable objects as well. Also included is a new feature for masking the input data so that the masked k-mers are not counted (or optionally, *only* the masked k-mers are counted).

These are tiny improvements with lots of practical utility.