### PR TITLE
Enable filtering cutouts/calls by sequence ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist/
 *.egg-info
 .ipynb_checkpoints/
 .eggs/
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ kevlar/*.cpython-*.so
 dist/
 *.egg-info
 .ipynb_checkpoints/
+.eggs/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help: Makefile
 
 ## devenv:   install software development pre-requisites
 devenv:
-	pip install --upgrade pip setuptools pytest pytest-cov pytest-xdist pycodestyle cython sphinx sphinx-argparse
+	pip install --upgrade pip setuptools pytest==3.6.4 pytest-cov pytest-xdist pycodestyle cython sphinx sphinx-argparse
 
 ## style:    check Python code style against PEP8
 style:

--- a/kevlar/cli/alac.py
+++ b/kevlar/cli/alac.py
@@ -7,6 +7,8 @@
 # licensed under the MIT license: see LICENSE.
 # -----------------------------------------------------------------------------
 
+import re
+
 
 def subparser(subparsers):
 
@@ -39,6 +41,12 @@ def subparser(subparsers):
                             'length of the longest contig; each bin specifies '
                             'a reference target sequence against which '
                             'assembled contigs will be aligned')
+    local_args.add_argument('--include', metavar='REGEX', type=re.escape,
+                            help='discard alignments to any chromosomes whose '
+                            'sequence IDs do not match the given pattern')
+    local_args.add_argument('--exclude', metavar='REGEX', type=re.escape,
+                            help='discard alignments to any chromosomes whose '
+                            'sequence IDs match the given pattern')
 
     score_args = subparser.add_argument_group('Alignment scoring')
     score_args.add_argument('-A', '--match', type=int, default=1, metavar='A',

--- a/kevlar/cli/localize.py
+++ b/kevlar/cli/localize.py
@@ -7,6 +7,8 @@
 # licensed under the MIT license: see LICENSE.
 # -----------------------------------------------------------------------------
 
+import re
+
 
 def subparser(subparsers):
     """Define the `kevlar localize` command-line interface."""
@@ -32,5 +34,12 @@ def subparser(subparsers):
                            'reference targets if the distance between two '
                            'seed matches is > X; by default, X is 3 times the '
                            'length of the longest contig')
+    subparser.add_argument('--include', metavar='REGEX', type=re.escape,
+                           help='discard alignments to any chromosomes whose '
+                           'sequence IDs do not match the given pattern')
+    subparser.add_argument('--exclude', metavar='REGEX', type=re.escape,
+                           help='discard alignments to any chromosomes whose '
+                           'sequence IDs match the given pattern')
     subparser.add_argument('contigs', help='assembled reads in Fasta format')
     subparser.add_argument('refr', help='BWA indexed reference genome')
+

--- a/kevlar/cli/localize.py
+++ b/kevlar/cli/localize.py
@@ -42,4 +42,3 @@ def subparser(subparsers):
                            'sequence IDs match the given pattern')
     subparser.add_argument('contigs', help='assembled reads in Fasta format')
     subparser.add_argument('refr', help='BWA indexed reference genome')
-

--- a/kevlar/tests/test_alac.py
+++ b/kevlar/tests/test_alac.py
@@ -144,6 +144,19 @@ def test_alac_single_partition_badlabel(capsys):
     assert out == ''
 
 
+def test_alac_exclude(capsys):
+    readfile = data_file('fiveparts.augfastq.gz')
+    refrfile = data_file('fiveparts-refr.fa.gz')
+    arglist = ['alac', '--exclude', '"^seq"', readfile, refrfile]
+    args = kevlar.cli.parser().parse_args(arglist)
+    kevlar.alac.main(args)
+    out, err = capsys.readouterr()
+
+    # grep -v ^'#' out
+    out = '\n'.join([l for l in out.split('\n') if not l.startswith('#')])
+    assert out == ''
+
+
 def test_alac_bigpart():
     readfile = data_file('fiveparts.augfastq.gz')
     refrfile = data_file('fiveparts-refr.fa.gz')

--- a/kevlar/tests/test_localize.py
+++ b/kevlar/tests/test_localize.py
@@ -57,7 +57,6 @@ def test_localizer_incl_excl():
         ('X', 1234, 1270),
     ]
 
-
     intervals.exclpattern = 'Un'
     testint = [c.interval for c in intervals.get_cutouts()]
     assert sorted(testint) == [
@@ -66,7 +65,7 @@ def test_localizer_incl_excl():
         ('X', 1234, 1270),
     ]
 
-    intervals.inclpattern = '^\d+$'
+    intervals.inclpattern = r'^\d+$'
     testint = [c.interval for c in intervals.get_cutouts()]
     assert sorted(testint) == [
         ('1', 100, 145),

--- a/kevlar/tests/test_localize.py
+++ b/kevlar/tests/test_localize.py
@@ -37,6 +37,43 @@ def test_localizer_simple():
     ]
 
 
+def test_localizer_incl_excl():
+    intervals = Localizer(seedsize=25)
+    intervals.add_seed_match('1', 100)
+    intervals.add_seed_match('1', 120)
+    intervals.add_seed_match('12', 200)
+    intervals.add_seed_match('12', 209)
+    intervals.add_seed_match('12', 213)
+    intervals.add_seed_match('X', 1234)
+    intervals.add_seed_match('X', 1245)
+    intervals.add_seed_match('Un', 13579)
+    intervals.add_seed_match('Un', 13597)
+
+    testint = [c.interval for c in intervals.get_cutouts()]
+    assert sorted(testint) == [
+        ('1', 100, 145),
+        ('12', 200, 238),
+        ('Un', 13579, 13622),
+        ('X', 1234, 1270),
+    ]
+
+
+    intervals.exclpattern = 'Un'
+    testint = [c.interval for c in intervals.get_cutouts()]
+    assert sorted(testint) == [
+        ('1', 100, 145),
+        ('12', 200, 238),
+        ('X', 1234, 1270),
+    ]
+
+    intervals.inclpattern = '^\d+$'
+    testint = [c.interval for c in intervals.get_cutouts()]
+    assert sorted(testint) == [
+        ('1', 100, 145),
+        ('12', 200, 238),
+    ]
+
+
 @pytest.mark.parametrize('infile', [
     ('smallseq.fa.gz'),
     ('smallseq.augfasta'),
@@ -178,14 +215,23 @@ def test_maxdiff(X, numtargets):
     assert len(targets) == numtargets
 
 
-def test_main(capsys):
+@pytest.mark.parametrize('incl,excl,output', [
+    (None, None, '>seq1_10-191'),
+    (r'seq1', None, '>seq1_10-191'),
+    (None, 'seq1', 'WARNING: no reference matches'),
+    (r'chr[XY]', None, 'WARNING: no reference matches'),
+    (None, r'b0Gu$', '>seq1_10-191'),
+])
+def test_main(incl, excl, output, capsys):
     contig = data_file('localize-contig.fa')
     refr = data_file('localize-refr.fa')
     arglist = ['localize', '--seed-size', '23', '--delta', '50', contig, refr]
     args = kevlar.cli.parser().parse_args(arglist)
+    args.include = incl
+    args.exclude = excl
     kevlar.localize.main(args)
     out, err = capsys.readouterr()
-    assert '>seq1_10-191' in out
+    assert output in out or output in err
 
 
 def test_main_no_matches(capsys):


### PR DESCRIPTION
kevlar often makes a lot of erroneous variant calls on sex chromosomes and alternate/decoy loci. This PR allows us to filter out any contigs that do not align to a canonical autosome, based on sequence ID.

`kevlar localize` and `kevlar alac` now have `--include` and `--exclude` flags to specify patterns (with regex) to test against sequence IDs to include or exclude from the results.