### PR TITLE
Improved logging, fixed --gen-mask bug

### DIFF
--- a/kevlar/alac.py
+++ b/kevlar/alac.py
@@ -33,7 +33,7 @@ def make_call_from_reads(queue, idx, calls, refrfile, ksize=31, delta=50,
             reads = queue.get()
             ccmatch = re.search(r'kvcc=(\d+)', reads[0].name)
             cc = ccmatch.group(1) if ccmatch else None
-            if cc is not None and int(cc) % 1000 == 0:
+            if cc is not None and int(cc) % 1000 == 0:  # pragma: no cover
                 message = '[kevlar::alac::make_call_from_reads'
                 message += ' (thread={:d})]'.format(idx)
                 message += ' grabbed partition={} from queue,'.format(cc)
@@ -106,7 +106,7 @@ def alac(pstream, refrfile, threads=1, ksize=31, bigpart=10000, delta=50,
             message = 'skipping partition with {:d} reads'.format(len(reads))
             print('[kevlar::alac] WARNING:', message, file=logstream)
             continue
-        if np % 1000 == 0:
+        if np % 1000 == 0:  # pragma: no cover
             message = '{} partitions scheduled for processing'.format(np)
             print('[kevlar::alac]', message, file=logstream)
         part_queue.put(reads)

--- a/kevlar/alac.py
+++ b/kevlar/alac.py
@@ -28,16 +28,17 @@ def make_call_from_reads(queue, idx, calls, refrfile, ksize=31, delta=50,
                          logstream=sys.stderr):
         while True:
             if queue.empty():
-                sleep(3)
+                sleep(1)
                 continue
             reads = queue.get()
             ccmatch = re.search(r'kvcc=(\d+)', reads[0].name)
             cc = ccmatch.group(1) if ccmatch else None
-            message = '[kevlar::alac::make_call_from_reads'
-            message += ' (thread={:d})]'.format(idx)
-            message += ' grabbed partition={} from queue,'.format(cc)
-            message += ' queue size now {:d}'.format(queue.qsize())
-            print(message, file=sys.stderr)
+            if int(cc) % 1000 == 0:
+                message = '[kevlar::alac::make_call_from_reads'
+                message += ' (thread={:d})]'.format(idx)
+                message += ' grabbed partition={} from queue,'.format(cc)
+                message += ' queue size now {:d}'.format(queue.qsize())
+                print(message, file=logstream)
 
             # Assemble partitioned reads into contig(s)
             contigs = list(assemble_fml_asm(reads, logstream=logstream))
@@ -77,6 +78,8 @@ def alac(pstream, refrfile, threads=1, ksize=31, bigpart=10000, delta=50,
          maskfile=None, maskmem=1e6, maskmaxfpr=0.01, logstream=sys.stderr):
     part_queue = Queue(maxsize=max(32, 12 * threads))
 
+    message = 'loading reference genome into memory'
+    print('[kevlar::alac]', message, file=logstream)
     refrstream = kevlar.open(refrfile, 'r')
     refrseqs = kevlar.seqio.parse_seq_dict(refrstream)
 
@@ -95,14 +98,15 @@ def alac(pstream, refrfile, threads=1, ksize=31, bigpart=10000, delta=50,
         worker.setDaemon(True)
         worker.start()
 
-    for partition in pstream:
+    for np, partition in enumerate(pstream, 1):
         reads = list(partition)
         if len(reads) > bigpart:
             message = 'skipping partition with {:d} reads'.format(len(reads))
             print('[kevlar::alac] WARNING:', message, file=logstream)
             continue
-        message = 'adding partition with {} reads to queue'.format(len(reads))
-        print('[kevlar::alac]', message, file=logstream)
+        if np % 1000 == 0:
+            message = '{} partitions scheduled for processing'.format(np)
+            print('[kevlar::alac]', message, file=logstream)
         part_queue.put(reads)
 
     part_queue.join()
@@ -135,7 +139,8 @@ def main(args):
         maxdiff=args.max_diff, inclpattern=args.include,
         exclpattern=args.exclude, match=args.match, mismatch=args.mismatch,
         gapopen=args.open, gapextend=args.extend, min_ikmers=args.min_ikmers,
-        logstream=args.logfile
+        maskfile=args.gen_mask, maskmem=args.mask_mem,
+        maskmaxfpr=args.mask_max_fpr, logstream=args.logfile
     )
 
     writer = kevlar.vcf.VCFWriter(

--- a/kevlar/alac.py
+++ b/kevlar/alac.py
@@ -82,6 +82,8 @@ def alac(pstream, refrfile, threads=1, ksize=31, bigpart=10000, delta=50,
     print('[kevlar::alac]', message, file=logstream)
     refrstream = kevlar.open(refrfile, 'r')
     refrseqs = kevlar.seqio.parse_seq_dict(refrstream)
+    message = 'done! Loading partitioned reads...'
+    print('[kevlar::alac]', message, file=logstream)
 
     call_lists = list()
     for idx in range(threads):

--- a/kevlar/alac.py
+++ b/kevlar/alac.py
@@ -33,7 +33,7 @@ def make_call_from_reads(queue, idx, calls, refrfile, ksize=31, delta=50,
             reads = queue.get()
             ccmatch = re.search(r'kvcc=(\d+)', reads[0].name)
             cc = ccmatch.group(1) if ccmatch else None
-            if int(cc) % 1000 == 0:
+            if cc is not None and int(cc) % 1000 == 0:
                 message = '[kevlar::alac::make_call_from_reads'
                 message += ' (thread={:d})]'.format(idx)
                 message += ' grabbed partition={} from queue,'.format(cc)

--- a/kevlar/augment.py
+++ b/kevlar/augment.py
@@ -34,7 +34,8 @@ def augment(augseqstream, nakedseqstream, collapsemates=False, upint=10000):
         assert len(record.mates) in (0, 1)
         if len(record.mates) == 1:
             mateseqs[record.name] = record.mates[0]
-    print('[kevlar::augment] done loading input', file=sys.stderr)
+    if n > 100:
+        print('[kevlar::augment] done loading input', file=sys.stderr)
 
     for record in nakedseqstream:
         qual = None


### PR DESCRIPTION
This update addresses two issues:

1. The excessive amount of logging output produced during `kevlar alac` has been reduced.
2. A bug that failed to pass the command line `--gen-mask` argument to the `alac` function has been fixed.