### PR TITLE
Fix erroneous contig attribute with indels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Corrected a bug that reported the reference target sequence instead of the assembled contig sequence in the `CONTIG` attribute of indel calls in the VCF (see #304).
+
+
 ## [0.6.1] 2018-11-16
 
 ### Fixed

--- a/kevlar/tests/test_call.py
+++ b/kevlar/tests/test_call.py
@@ -148,6 +148,7 @@ def test_funky_cigar_deletion():
     assert calls[0].position == 53644
     assert calls[0]._refr == 'ATGTCTGTTTTCTTAACCT'
     assert calls[0]._alt == 'A'
+    assert calls[0].attribute('CONTIG') == contigs[0].sequence
 
 
 def test_perfect_match():

--- a/kevlar/varmap.py
+++ b/kevlar/varmap.py
@@ -279,7 +279,7 @@ class VariantMapping(object):
         globalcoord = self.cutout.local_to_global(localcoord)
         indel = Variant(
             self.seqid, globalcoord - 1, refrallele, altallele,
-            CONTIG=self.refrseq, CIGAR=self.cigar, KSW2=str(self.score),
+            CONTIG=self.varseq, CIGAR=self.cigar, KSW2=str(self.score),
             IKMERS=str(nikmers), ALTWINDOW=altwindow, REFRWINDOW=refrwindow
         )
         yield indel


### PR DESCRIPTION
This update fixes a bug that reports the reference target sequence instead of the assembled contig in the `CONTIG` VCF attribute of any indel call. The assembled contig sequence is now correctly reported.