### PR TITLE
Minor updates to workflow Mark I

### DIFF
--- a/kevlar/workflows/mark-I/Snakefile
+++ b/kevlar/workflows/mark-I/Snakefile
@@ -301,7 +301,7 @@ rule localize:
         'Logs/localize.log'
     threads: 1
     message: 'Compute reference target sequences for each partition.'
-    shell: 'kevlar --tee --logfile {output[1]} localize --delta {config[localize][delta]} --seed-size {config[localize][seedsize]} --include {config[localize][seqpattern]} --out {output[0]} {input[0]} {input[1]}'
+    shell: 'kevlar --tee --logfile {output[1]} localize --delta {config[localize][delta]} --seed-size {config[localize][seedsize]} --include \'{config[localize][seqpattern]}\' --out {output[0]} {input[0]} {input[1]}'
 
 
 rule call:

--- a/kevlar/workflows/mark-I/config.json
+++ b/kevlar/workflows/mark-I/config.json
@@ -53,6 +53,7 @@
     "localize": {
         "seedsize": 51,
         "delta": 50,
-        "seqpattern": "."
+        "seqpattern": ".",
+        "maxdiff": 10000
     }
 }


### PR DESCRIPTION
- fix regex escaping issue
- update `maxdiff` default value to something capable of detecting large deletions

Fixes #310.