### PR TITLE
Split workflow

### DIFF
--- a/kevlar/call.py
+++ b/kevlar/call.py
@@ -171,6 +171,8 @@ def main(args):
     )
     for partid, gdnas in gdnastream:
         progress_indicator.update()
+        if partid not in contigs_by_partition:
+            continue
         contigs = contigs_by_partition[partid]
         caller = call(
             gdnas, contigs, partid, match=args.match, mismatch=args.mismatch,

--- a/kevlar/cli/localize.py
+++ b/kevlar/cli/localize.py
@@ -45,5 +45,6 @@ def subparser(subparsers):
     subparser.add_argument('--exclude', metavar='REGEX', type=str,
                            help='discard alignments to any chromosomes whose '
                            'sequence IDs match the given pattern')
-    subparser.add_argument('contigs', help='assembled reads in Fasta format')
     subparser.add_argument('refr', help='BWA indexed reference genome')
+    subparser.add_argument('contigs', nargs='+', help='assembled reads in '
+                           'augmented Fasta format')

--- a/kevlar/cli/simlike.py
+++ b/kevlar/cli/simlike.py
@@ -60,4 +60,4 @@ def subparser(subparsers):
     misc_args.add_argument('--case-min', metavar='Y', type=int, default=5,
                            help='minimum abundance threshold for proband; '
                            'default is 5')
-    subparser.add_argument('vcf')
+    subparser.add_argument('vcf', nargs='+')

--- a/kevlar/localize.py
+++ b/kevlar/localize.py
@@ -225,7 +225,7 @@ def localize(partstream, refrfile, seedsize=51, delta=50, maxdiff=None,
 
 
 def main(args):
-    contigstream = kevlar.parse_augmented_fastx(kevlar.open(args.contigs, 'r'))
+    contigstream = kevlar.seqio.afxstream(args.contigs)
     if args.part_id:
         pstream = kevlar.parse_single_partition(contigstream, args.part_id)
     else:

--- a/kevlar/simlike.py
+++ b/kevlar/simlike.py
@@ -265,9 +265,8 @@ def main(args):
     controls = [khmer.Counttable.load(c) for c in args.controls]
     refr = khmer.SmallCounttable.load(args.refr)
 
-    instream = kevlar.open(args.vcf, 'r')
+    reader = kevlar.vcf.vcfstream(args.vcf)
     outstream = kevlar.open(args.out, 'w')
-    reader = kevlar.vcf.VCFReader(instream)
     writer = kevlar.vcf.VCFWriter(outstream, source='kevlar::simlike')
 
     for label in args.sample_labels:

--- a/kevlar/split.py
+++ b/kevlar/split.py
@@ -35,7 +35,7 @@ def main(args):
     partstream = kevlar.parse_partitioned_reads(readstream)
     outstreams = list()
     for i in range(args.numfiles):
-        outfile = '{:s}.{:d}.augfastx'.format(args.base, i + 1)
+        outfile = '{:s}.{:d}.augfastx'.format(args.base, i)
         if args.infile.endswith('.gz'):
             outfile += '.gz'
         os = kevlar.open(outfile, 'w')

--- a/kevlar/split.py
+++ b/kevlar/split.py
@@ -11,12 +11,22 @@ from itertools import cycle
 import kevlar
 
 
-def split(pstream, outstreams):
+def split(pstream, outstreams, maxreads=10000):
     """Split the partitions across the N outstreams."""
+    progress_indicator = kevlar.ProgressIndicator(
+        '[kevlar::split] processed {counter} partitions',
+        interval=100, breaks=[1000, 10000, 100000], usetimer=True,
+    )
     for partdata, outstream in zip(pstream, cycle(outstreams)):
         partid, partition = partdata
+        if len(partition) > maxreads:
+            message = 'WARNING: discarding partition '
+            message += 'with {} reads'.format(len(partition))
+            kevlar.plog('[kevlar::split]', message)
+            continue
         for read in partition:
             kevlar.print_augmented_fastx(read, outstream)
+        progress_indicator.update()
 
 
 def main(args):
@@ -25,7 +35,9 @@ def main(args):
     partstream = kevlar.parse_partitioned_reads(readstream)
     outstreams = list()
     for i in range(args.numfiles):
-        outfile = '{:s}.{:d}'.format(args.base, i + 1)
+        outfile = '{:s}.{:d}.augfastx'.format(args.base, i + 1)
+        if args.infile.endswith('.gz'):
+            outfile += '.gz'
         os = kevlar.open(outfile, 'w')
         outstreams.append(os)
     split(partstream, outstreams)

--- a/kevlar/tests/test_localize.py
+++ b/kevlar/tests/test_localize.py
@@ -196,7 +196,7 @@ def test_maxdiff(X, numtargets):
 def test_main(incl, excl, output, capsys):
     contig = data_file('localize-contig.fa')
     refr = data_file('localize-refr.fa')
-    arglist = ['localize', '--seed-size', '23', '--delta', '50', contig, refr]
+    arglist = ['localize', '--seed-size', '23', '--delta', '50', refr, contig]
     args = kevlar.cli.parser().parse_args(arglist)
     args.include = incl
     args.exclude = excl
@@ -209,7 +209,7 @@ def test_main(incl, excl, output, capsys):
 def test_main_no_matches(capsys):
     contig = data_file('localize-contig-bad.fa')
     refr = data_file('localize-refr.fa')
-    arglist = ['localize', '--seed-size', '23', contig, refr]
+    arglist = ['localize', '--seed-size', '23', refr, contig]
     args = kevlar.cli.parser().parse_args(arglist)
     kevlar.localize.main(args)
     out, err = capsys.readouterr()
@@ -318,7 +318,7 @@ def test_localize_cli(capsys):
     refr_file = data_file('fiveparts-refr.fa.gz')
     contig_file = data_file('fiveparts.contigs.augfasta.gz')
 
-    arglist = ['localize', '--part-id', '2', contig_file, refr_file]
+    arglist = ['localize', '--part-id', '2', refr_file, contig_file]
     args = kevlar.cli.parser().parse_args(arglist)
     kevlar.localize.main(args)
     out, err = capsys.readouterr()
@@ -331,7 +331,7 @@ def test_localize_cli(capsys):
         'CTGGCTTGCCTTGACCCCA\n'
     )
 
-    arglist = ['localize', contig_file, refr_file]
+    arglist = ['localize', refr_file, contig_file]
     args = kevlar.cli.parser().parse_args(arglist)
     kevlar.localize.main(args)
     out, err = capsys.readouterr()

--- a/kevlar/tests/test_split.py
+++ b/kevlar/tests/test_split.py
@@ -38,7 +38,7 @@ def test_split_cli():
     args = kevlar.cli.parser().parse_args(arglist)
     kevlar.split.main(args)
 
-    outfile = tempdir + '/out.1'
+    outfile = tempdir + '/out.0.augfastx.gz'
     readstream = kevlar.parse_augmented_fastx(kevlar.open(outfile, 'r'))
     partstream = kevlar.parse_partitioned_reads(readstream)
     partitions = list(partstream)
@@ -47,7 +47,7 @@ def test_split_cli():
     assert len(partitions[0]) == 67
     assert len(partitions[1]) == 12
 
-    outfile = tempdir + '/out.2'
+    outfile = tempdir + '/out.1.augfastx.gz'
     readstream = kevlar.parse_augmented_fastx(kevlar.open(outfile, 'r'))
     partstream = kevlar.parse_partitioned_reads(readstream)
     partitions = list(partstream)
@@ -56,7 +56,7 @@ def test_split_cli():
     assert len(partitions[0]) == 23
     assert len(partitions[1]) == 11
 
-    outfile = tempdir + '/out.3'
+    outfile = tempdir + '/out.2.augfastx.gz'
     readstream = kevlar.parse_augmented_fastx(kevlar.open(outfile, 'r'))
     partstream = kevlar.parse_partitioned_reads(readstream)
     partitions = list(partstream)

--- a/kevlar/vcf.py
+++ b/kevlar/vcf.py
@@ -429,3 +429,10 @@ class VCFReader(object):
         if len(fields) == 8:
             return
         self._sample_labels = fields[9:]
+
+
+def vcfstream(filelist):
+    for infile in filelist:
+        reader = VCFReader(kevlar.open(infile, 'r'))
+        for record in reader:
+            yield record

--- a/kevlar/workflows/mark-I/Snakefile
+++ b/kevlar/workflows/mark-I/Snakefile
@@ -278,15 +278,22 @@ rule partition:
     shell: 'kevlar --tee --logfile {output[1]} partition --min-abund {config[samples][casemin]} --out {output[0]} {input}'
 
 
+rule split:
+    input: 'NovelReads/partitioned.augfastq.gz'
+    output: expand('NovelReads/partitioned.{num}.augfastx.gz', num=range(config['numsplit']))
+    threads: 1
+    shell: 'kevlar split {input} {config[numsplit]} NovelReads/partitioned'
+
+
 # -----------------------------------------------------------------------------
 # Assemble, localize, align, make preliminary calls, and score/sort calls.
 # -----------------------------------------------------------------------------
 
 rule assemble:
-    input: 'NovelReads/partitioned.augfastq.gz'
+    input: 'NovelReads/partitioned.{num}.augfastx.gz'
     output:
-        'contigs.augfasta.gz',
-        'Logs/assemble.log'
+        'contigs.{num}.augfasta.gz',
+        'Logs/assemble.{num}.log'
     threads: 1
     message: 'Assemble reads into contigs partition by partition.'
     shell: 'kevlar --tee --logfile {output[1]} assemble --out {output[0]} {input}'
@@ -294,41 +301,41 @@ rule assemble:
 
 rule localize:
     input:
-        'contigs.augfasta.gz',
-        simplex.refr_files
+        simplex.refr_files[0],
+        expand('contigs.{num}.augfasta.gz', num=range(config['numsplit'])),
     output:
         'reference.gdnas.fa.gz',
         'Logs/localize.log'
     threads: 1
     message: 'Compute reference target sequences for each partition.'
-    shell: 'kevlar --tee --logfile {output[1]} localize --delta {config[localize][delta]} --seed-size {config[localize][seedsize]} --include \'{config[localize][seqpattern]}\' --out {output[0]} {input[0]} {input[1]}'
+    shell: 'kevlar --tee --logfile {output[1]} localize --delta {config[localize][delta]} --seed-size {config[localize][seedsize]} --include \'{config[localize][seqpattern]}\' --out {output[0]} {input}'
 
 
 rule call:
     input:
-        'contigs.augfasta.gz',
+        'contigs.{num}.augfasta.gz',
         'reference.gdnas.fa.gz',
         simplex.refr_files[0]
     output:
-        'calls.prelim.vcf.gz',
-        'Sketches/spanning-kmers.nodetable',
-        'Logs/call.log'
+        'calls.{num}.prelim.vcf.gz',
+        'Logs/call.{num}.log'
     threads: 1
     message: 'Align contigs to reference targets and make preliminary calls.'
-    shell: 'kevlar --tee --logfile {output[2]} call --gen-mask {output[1]} --mask-mem 10M --refr {input[2]} --ksize {config[ksize]} --out {output[0]} {input[0]} {input[1]}'
+    shell: 'kevlar --tee --logfile {output[1]} call --mask-mem 10M --refr {input[2]} --ksize {config[ksize]} --out {output[0]} {input[0]} {input[1]}'
 
 
 rule like_scores:
     input:
-        'calls.prelim.vcf.gz',
         'Reference/refr-counts.smallcounttable',
-        simplex.all_sample_counts
+        simplex.all_sample_counts,
+        expand('calls.{num}.prelim.vcf.gz', num=range(config['numsplit']))
     output:
         'calls.scored.sorted.vcf.gz',
         'Logs/simlike.log'
     threads: 1
     message: 'Filter calls, compute likelihood scores, and sort calls by score.'
     run:
+        in_vcfs = expand('calls.{num}.prelim.vcf.gz', num=range(config['numsplit']))
         cmd = [
             'kevlar', '--tee', '--logfile', output[1], 'simlike',
             '--mu', config['samples']['coverage']['mean'],
@@ -337,7 +344,7 @@ rule like_scores:
             '--refr', 'Reference/refr-counts.smallcounttable',
             '--sample-labels', *simplex.sample_labels, '--out', output[0],
             '--controls', *simplex.control_sample_counts,
-            '--case', simplex.case_sample_counts, input[0]
+            '--case', simplex.case_sample_counts, *in_vcfs
         ]
         cmd = [str(arg) for arg in cmd]
         cmd = ' '.join(cmd)

--- a/kevlar/workflows/mark-I/config.json
+++ b/kevlar/workflows/mark-I/config.json
@@ -1,6 +1,7 @@
 {
     "ksize": 31,
     "recountmem": "1G",
+    "numsplit": 16,
     "samples": {
         "casemin": 6,
         "ctrlmax": 1,


### PR DESCRIPTION
Accelerating the assemble/localize/align/call portion of the workflow via Python's threading module has proven unsuccessful, despite its dispatch of the assembly tasks the C extensions. This update modifies the `split`, `localize`, `call`, and `simlike` modules and the mark I Snakemake workflow to support parallel processing during that portion of the procedure.