### PR TITLE
Dynamically compute length of output for functional test

### DIFF
--- a/kevlar/tests/test_alac.py
+++ b/kevlar/tests/test_alac.py
@@ -73,7 +73,12 @@ def test_pico_partitioned(capsys):
 
     out, err = capsys.readouterr()
     lines = out.strip().split('\n')
-    assert len(lines) == 36
+    nmetalines = 4  # filteformat filteDate source reference
+    nfilterlines = len(kevlar.vcf.VCFWriter.filter_desc)
+    ninfolines = len(kevlar.vcf.VCFWriter.info_metadata)
+    nformatlines = 1
+    nheaderlines = nmetalines + nfilterlines + ninfolines + nformatlines + 1
+    assert len(lines) == nheaderlines + 10
     lines = [l for l in lines if not l.startswith('#')]
     assert len(lines) == 10
     numnocalls = sum([1 for line in lines if '\t.\t.\t.\t.\t' in line])


### PR DESCRIPTION
Recently, any change to kevlar's VCF output (such as adding a new FILTER value with a corresponding description field) required manually updating the `test_alac.py::test_pico_partitioned` functional test. Among other things, this test measures the number of lines in the VCF output file. Until now it's used a hard-coded value, which of course has to be updated whenever the VCF output is expanded.

This update fixes the test so that it dynamically computes the expected number of lines of output, so that in the future no more trivial updates to the test are required.