### PR TITLE
Update to variant.annotate

### DIFF
--- a/kevlar/sandbox/subsketch.py
+++ b/kevlar/sandbox/subsketch.py
@@ -24,7 +24,7 @@ allocators = {
 
 
 cli = argparse.ArgumentParser()
-cli.add_argument('--sketch-type', metvar='T', choices=loaders.keys(), default='counttable', help='Sketch type to use for output')
+cli.add_argument('--sketch-type', metavar='T', choices=allocators.keys(), default='counttable', help='Sketch type to use for output')
 cli.add_argument('--num-tables', type=int, default=4, metavar='N')
 cli.add_argument('--table-size', type=int, default=1000, metavar='X')
 cli.add_argument('sketch', help='original sketch')

--- a/kevlar/tests/test_vcf.py
+++ b/kevlar/tests/test_vcf.py
@@ -101,17 +101,20 @@ def test_info():
     v = Variant('1', 12345, 'G', 'C')
     assert v.attribute('VW') is None
 
+    v.annotate('VW', 'AGTNNNNNNNNNNNNNNNNNNNNNTGA')
+    assert v.attribute('VW') == 'AGTNNNNNNNNNNNNNNNNNNNNNTGA'
+
     v.annotate('VW', 'GATTACA')
     assert v.attribute('VW') == 'GATTACA'
     assert v.attribute('VW', pair=True) == 'VW=GATTACA'
 
-    v.annotate('VW', 'ATGCCCTAG')
+    v.annotate('VW', 'ATGCCCTAG', replace=False)
     assert v.info['VW'] == ['GATTACA', 'ATGCCCTAG']
     assert v.attribute('VW') == ['GATTACA', 'ATGCCCTAG']
     assert v.attribute('VW', string=True) == 'GATTACA,ATGCCCTAG'
     assert v.attribute('VW', pair=True) == 'VW=GATTACA,ATGCCCTAG'
 
-    v.annotate('VW', 'AAAAAAAAA')
+    v.annotate('VW', 'AAAAAAAAA', replace=False)
     assert v.attribute('VW') == ['GATTACA', 'ATGCCCTAG', 'AAAAAAAAA']
     assert v.attribute('VW', pair=True) == 'VW=GATTACA,ATGCCCTAG,AAAAAAAAA'
 
@@ -119,13 +122,13 @@ def test_info():
     assert v.attribute('DROPPED') == 3
     assert v.attribute('DROPPED', string=True) == '3'
 
-    v.annotate('DROPPED', 31)
+    v.annotate('DROPPED', 31, replace=False)
     assert v.attribute('DROPPED') == [3, 31]
     assert v.attribute('DROPPED', string=True) == '3,31'
     assert v.attribute('DROPPED', pair=True) == 'DROPPED=3,31'
 
-    v.annotate('MATEDIST', 432.1234)
-    v.annotate('MATEDIST', 8765.4321)
+    v.annotate('MATEDIST', 432.1234, replace=False)
+    v.annotate('MATEDIST', 8765.4321, replace=False)
     assert v.attribute('MATEDIST', string=True) == '432.123,8765.432'
 
     v.annotate('LLIH', -436.0111857750478)

--- a/kevlar/vcf.py
+++ b/kevlar/vcf.py
@@ -171,8 +171,11 @@ class Variant(object):
         """Similar to `window`, but encapsulating the reference allele."""
         return self.attribute('REFRWINDOW')
 
-    def annotate(self, key, value):
-        self.info[key].append(value)
+    def annotate(self, key, value, replace=True):
+        if replace:
+            self.info[key] = FormattedList([value])
+        else:
+            self.info[key].append(value)
 
     def attribute(self, key, pair=False, string=False):
         """Query annotated INFO data.


### PR DESCRIPTION
This update modifies the default behavior of the `variant.annotate` method. Before, it would append values by default. Now it replaces all values by default. The old behavior can be retained with `replace=False`. Closes #347.