### PR TITLE
Check number of controls

### DIFF
--- a/kevlar/tests/test_alac.py
+++ b/kevlar/tests/test_alac.py
@@ -24,7 +24,7 @@ def test_pico_4(capsys):
     out, err = capsys.readouterr()
 
     # grep -v ^'#' out
-    out = '\n'.join([l for l in out.split('\n') if not l.startswith('#')])
+    out = '\n'.join([ln for ln in out.split('\n') if not ln.startswith('#')])
 
     vcf = '\t'.join([
         'seq1', '1175768', '.', 'T', 'C', '.', 'PASS',
@@ -79,7 +79,7 @@ def test_pico_partitioned(capsys):
     nformatlines = 1
     nheaderlines = nmetalines + nfilterlines + ninfolines + nformatlines + 1
     assert len(lines) == nheaderlines + 10
-    lines = [l for l in lines if not l.startswith('#')]
+    lines = [ln for ln in lines if not ln.startswith('#')]
     assert len(lines) == 10
     numnocalls = sum([1 for line in lines if '\t.\t.\t.\t.\t' in line])
     assert numnocalls == 2
@@ -147,7 +147,7 @@ def test_alac_single_partition_badlabel(capsys):
     out, err = capsys.readouterr()
 
     # grep -v ^'#' out
-    out = '\n'.join([l for l in out.split('\n') if not l.startswith('#')])
+    out = '\n'.join([ln for ln in out.split('\n') if not ln.startswith('#')])
     assert out == ''
 
 
@@ -161,7 +161,7 @@ def test_alac_exclude(capsys):
     print(err)
 
     # grep -v ^'#' out
-    out = '\n'.join([l for l in out.split('\n') if not l.startswith('#')])
+    out = '\n'.join([ln for ln in out.split('\n') if not ln.startswith('#')])
     assert out == ''
 
 

--- a/kevlar/tests/test_call.py
+++ b/kevlar/tests/test_call.py
@@ -448,7 +448,7 @@ def test_call_max_target_length_cli(capsys):
 
     out, err = capsys.readouterr()
     outlines = out.strip().split('\n')
-    calllines = [l for l in outlines if not l.startswith('#')]
+    calllines = [ln for ln in outlines if not ln.startswith('#')]
     assert len(calllines) == 1
     assert calllines[0].startswith('.\t.\t.\t.\t.')
     assert 'PASS' not in calllines[0]

--- a/kevlar/tests/test_progress.py
+++ b/kevlar/tests/test_progress.py
@@ -38,6 +38,6 @@ def test_progress_timer(capsys):
     out, err = capsys.readouterr()
     print(err)
     loglines = err.strip().split('\n')
-    timelines = [l for l in loglines if 'seconds elapsed' in l]
+    timelines = [ln for ln in loglines if 'seconds elapsed' in ln]
     assert len(loglines) == 20
     assert len(timelines) == 20

--- a/kevlar/tests/test_vcf.py
+++ b/kevlar/tests/test_vcf.py
@@ -166,12 +166,12 @@ def test_writer(yrb_writer, capsys):
     print(out)
 
     outlines = out.strip().split('\n')
-    fmtlines = [l for l in outlines if l.startswith('##FORMAT')]
+    fmtlines = [ln for ln in outlines if ln.startswith('##FORMAT')]
     assert len(fmtlines) == 2
     gtfmt = '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">'
     assert gtfmt in fmtlines
 
-    varlines = [l for l in outlines if not l.startswith('#')]
+    varlines = [ln for ln in outlines if not ln.startswith('#')]
     assert len(varlines) == 1
     values = varlines[0].split('\t')
     assert len(values) == 12

--- a/kevlar/workflows/mark-I/Snakefile
+++ b/kevlar/workflows/mark-I/Snakefile
@@ -5,6 +5,7 @@
 # licensed under the MIT license: see LICENSE.
 # -----------------------------------------------------------------------------
 import os
+import sys
 
 
 # -----------------------------------------------------------------------------
@@ -140,6 +141,22 @@ class SimplexDesign(object):
 
 
 simplex = SimplexDesign(config)
+if simplex.numcontrols <= 1:
+    message = (
+        "this particular workflow is optimized for simplex cases with a single case sample "
+        "(proband or affected child) and two or more control samples (parents and, if available, "
+        "unaffected sibling); there are no guarantees for how Kevlar performs with only a single "
+        "parent or controlsample: most of the workflow will likely succeed, but the final `kevlar "
+        "simlike` step will almost certainly fail"
+    )
+    if "controlcheck" in config and config["controlcheck"] is False:
+        print("[WARNING]", message, file=sys.stderr)
+    else:
+        message += (
+            "; set 'controlcheck: true' in the config file to ignore and override this warning"
+        )
+        print("[ERROR]", message, file=sys.stderr)
+        raise ValueError(simplex.numcontrols)
 
 
 # -----------------------------------------------------------------------------

--- a/kevlar/workflows/mark-I/config.json
+++ b/kevlar/workflows/mark-I/config.json
@@ -57,5 +57,6 @@
         "seqpattern": ".",
         "maxdiff": 10000
     },
-    "varfilter": null
+    "varfilter": null,
+    "controlcheck": true
 }


### PR DESCRIPTION
Provide better warning/error messages if users attempt to run the simplex Snakemake workflow with only a single parent/control.